### PR TITLE
Improve SSO Flow

### DIFF
--- a/src/AuthenticationServiceProvider.php
+++ b/src/AuthenticationServiceProvider.php
@@ -59,7 +59,8 @@ class AuthenticationServiceProvider extends ServiceProvider
         // Slap in the Eveonline Socialite Provider
         $eveonline = $this->app->make('Laravel\Socialite\Contracts\Factory');
 
-        $eveonline->extend('eveonline',
+        $eveonline->extend(
+            'eveonline',
             function ($app) use ($eveonline) {
                 $config = $app['config']['services.eveonline'];
 
@@ -68,7 +69,8 @@ class AuthenticationServiceProvider extends ServiceProvider
         );
 
         $this->mergeConfigFrom(
-            __DIR__.'/config/permission.php', 'permission'
+            __DIR__.'/config/permission.php',
+            'permission'
         );
     }
 }

--- a/src/Extentions/EveOnlineProvider.php
+++ b/src/Extentions/EveOnlineProvider.php
@@ -64,7 +64,8 @@ class EveOnlineProvider extends AbstractProvider implements ProviderInterface
 
         $user = $this->mapUserToObject(
             array_merge(
-                $this->getUserByToken($tokens['access_token']), [
+                $this->getUserByToken($tokens['access_token']),
+                [
                     'RefreshToken' => $tokens['refresh_token'],
                 ]
             )
@@ -122,7 +123,9 @@ class EveOnlineProvider extends AbstractProvider implements ProviderInterface
     protected function getAuthUrl($state)
     {
         return $this->buildAuthUrlFromBase(
-            'https://login.eveonline.com/oauth/authorize', $state);
+            'https://login.eveonline.com/oauth/authorize',
+            $state
+        );
     }
 
     /**

--- a/src/Http/Actions/Sso/UpdateRefreshTokenAction.php
+++ b/src/Http/Actions/Sso/UpdateRefreshTokenAction.php
@@ -35,8 +35,9 @@ class UpdateRefreshTokenAction
     {
         // To prevent overwriting a perfectly fine refresh_token of users without a valid session
         // simply ignore the returned refresh_token as it would only contain public_data scope
-        if(auth()->guest() && RefreshToken::where('character_id',$eve_data->character_id)->get()->isNotEmpty())
+        if (auth()->guest() && RefreshToken::where('character_id', $eve_data->character_id)->get()->isNotEmpty()) {
             return;
+        }
 
         RefreshToken::withTrashed()->firstOrNew(['character_id' => $eve_data->character_id])
             ->fill([

--- a/src/Http/Actions/Sso/UpdateRefreshTokenAction.php
+++ b/src/Http/Actions/Sso/UpdateRefreshTokenAction.php
@@ -33,6 +33,11 @@ class UpdateRefreshTokenAction
 {
     public function execute(EveUser $eve_data)
     {
+        // To prevent overwriting a perfectly fine refresh_token of users without a valid session
+        // simply ignore the returned refresh_token as it would only contain public_data scope
+        if(auth()->guest() && RefreshToken::where('character_id',$eve_data->character_id)->get()->isNotEmpty())
+            return;
+
         RefreshToken::withTrashed()->firstOrNew(['character_id' => $eve_data->character_id])
             ->fill([
                 'refresh_token' => $eve_data->refresh_token,

--- a/src/Http/Controllers/Auth/SsoController.php
+++ b/src/Http/Controllers/Auth/SsoController.php
@@ -74,7 +74,8 @@ class SsoController extends Controller
     public function handleProviderCallback(
         Socialite $social,
         FindOrCreateUserAction $find_or_create_user_action,
-        UpdateRefreshTokenAction $update_refresh_token_action)
+        UpdateRefreshTokenAction $update_refresh_token_action
+    )
     {
         $eve_data = $social->driver('eveonline')->user();
 

--- a/src/Http/Middleware/CheckRequiredScopes.php
+++ b/src/Http/Middleware/CheckRequiredScopes.php
@@ -96,7 +96,8 @@ class CheckRequiredScopes
     {
         return auth()->user()->characters()->has('alliance.ssoScopes')
             ->orHas('corporation.ssoScopes')
-            ->with('alliance.ssoScopes',
+            ->with(
+                'alliance.ssoScopes',
                 'corporation.ssoScopes',
                 'application.corporation.ssoScopes',
                 'application.corporation.alliance.ssoScopes'

--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -94,7 +94,7 @@ class User extends Authenticatable
             'character_id',
             'id',
             'character_id'
-            );
+        );
     }
 
     public function main_character()

--- a/src/database/migrations/2019_09_14_053230_create_permission_tables.php
+++ b/src/database/migrations/2019_09_14_053230_create_permission_tables.php
@@ -66,8 +66,10 @@ class CreatePermissionTables extends Migration
                 ->on($tableNames['permissions'])
                 ->onDelete('cascade');
 
-            $table->primary(['permission_id', $columnNames['model_morph_key'], 'model_type'],
-                'model_has_permissions_permission_model_type_primary');
+            $table->primary(
+                ['permission_id', $columnNames['model_morph_key'], 'model_type'],
+                'model_has_permissions_permission_model_type_primary'
+            );
         });
 
         Schema::create($tableNames['model_has_roles'], function (Blueprint $table) use ($tableNames, $columnNames) {
@@ -82,8 +84,10 @@ class CreatePermissionTables extends Migration
                 ->on($tableNames['roles'])
                 ->onDelete('cascade');
 
-            $table->primary(['role_id', $columnNames['model_morph_key'], 'model_type'],
-                'model_has_roles_role_model_type_primary');
+            $table->primary(
+                ['role_id', $columnNames['model_morph_key'], 'model_type'],
+                'model_has_roles_role_model_type_primary'
+            );
         });
 
         Schema::create($tableNames['role_has_permissions'], function (Blueprint $table) use ($tableNames) {

--- a/tests/Feature/Auth/SsoControllerTest.php
+++ b/tests/Feature/Auth/SsoControllerTest.php
@@ -114,7 +114,7 @@ class SsoControllerTest extends TestCase
         $this->assertEquals(
             'Something might have gone wrong. You might have changed the requested scopes on esi, please refer from doing so.',
             session('error')
-            );
+        );
     }
 
     private function createSocialiteUser($character_id, $refresh_token = 'refresh_token', $scopes = '1 2', $token = 'qq3dpeTMpDkjNasdasdewva3Be658eVVkox_1Ikodc')

--- a/tests/Unit/FindOrCreateUserActionTest.php
+++ b/tests/Unit/FindOrCreateUserActionTest.php
@@ -145,7 +145,8 @@ class FindOrCreateUserActionTest extends TestCase
         $socialiteUser = $this->createSocialUserMock(
             $this->test_user->character_users->first()->character_id,
             $this->test_user->main_character,
-            'anotherHashValue');
+            'anotherHashValue'
+        );
 
         // 3. find user
 

--- a/tests/Unit/UpdateRefreshTokenActionTest.php
+++ b/tests/Unit/UpdateRefreshTokenActionTest.php
@@ -102,7 +102,7 @@ class UpdateRefreshTokenActionTest extends TestCase
 
         $eve_data = $this->createSocialiteUser($this->test_user->id, 'new_refreshToken');
 
-        (new UpdateRefreshTokenAction)->execute($eve_data);
+        (new UpdateRefreshTokenAction())->execute($eve_data);
 
         $this->assertDatabaseMissing('refresh_tokens', [
             'character_id'  => $this->test_user->id,


### PR DESCRIPTION
Users without a valid session but with a valid refresh_token will not overwrite the existing refresh token anymore.