### PR TITLE
Feature/query assigned ids

### DIFF
--- a/.github/workflows/laravel.yml
+++ b/.github/workflows/laravel.yml
@@ -22,7 +22,7 @@ jobs:
     - uses: getong/mariadb-action@v1.1
       with:
         host port: 3308 # Optional, default value is 3306. The port of host
-        mariadb version: '10.3' # Optional, default value is "latest". The version of the MariaDB
+        mariadb version: '10.7' # Optional, default value is "latest". The version of the MariaDB
         mysql database: 'testbench' # Optional, default value is "test". The specified database which will be create
         mysql user: 'default' # Required if "mysql root password" is empty, default is empty. The superuser for the specified database. Can use secrets, too
         mysql password: 'secret' # Required if "mysql user" exists. The password for the "mysql user"

--- a/composer.json
+++ b/composer.json
@@ -35,10 +35,8 @@
     "require-dev": {
         "orchestra/testbench": "^7.0",
         "nunomaduro/collision": "^6.1",
-        "brianium/paratest": "^6.2",
         "pestphp/pest": "^1.18",
-        "pestphp/pest-plugin-laravel": "^1.2",
-        "pestphp/pest-plugin-parallel": "^0.3.1"
+        "pestphp/pest-plugin-laravel": "^1.2"
     },
     "extra": {
         "laravel": {
@@ -49,8 +47,7 @@
     },
     "scripts": {
       "test": "vendor/bin/pest",
-      "test-coverage": "XDEBUG_MODE=coverage ./vendor/bin/pest --coverage",
-      "parallel": "XDEBUG_MODE=coverage ./vendor/bin/pest --coverage -p"
+      "test-coverage": "XDEBUG_MODE=coverage ./vendor/bin/pest --coverage"
     },
     "config": {
         "allow-plugins": {

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "php": "^8.1",
         "laravel/framework": "^9.0",
         "laravel/socialite": "^5.0",
-        "seatplus/eveapi": "^1.0",
+        "seatplus/eveapi": "*",
         "spatie/laravel-permission": "^5.4",
         "socialiteproviders/eveonline": "^4.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "php": "^8.1",
         "laravel/framework": "^9.0",
         "laravel/socialite": "^5.0",
-        "seatplus/eveapi": "*",
+        "seatplus/eveapi": "^1.0",
         "spatie/laravel-permission": "^5.4",
         "socialiteproviders/eveonline": "^4.0"
     },

--- a/src/Actions/GetAffiliatedIdsByPermissionArray.php
+++ b/src/Actions/GetAffiliatedIdsByPermissionArray.php
@@ -34,6 +34,9 @@ use Seatplus\Eveapi\Models\Alliance\AllianceInfo;
 use Seatplus\Eveapi\Models\Character\CharacterInfo;
 use Seatplus\Eveapi\Models\Corporation\CorporationInfo;
 
+/**
+ * @deprecated deprecated since version 2.0
+ */
 class GetAffiliatedIdsByPermissionArray
 {
     /**

--- a/src/Enums/AffiliationType.php
+++ b/src/Enums/AffiliationType.php
@@ -10,8 +10,7 @@ enum AffiliationType
 
     public function operator() : string
     {
-        return match ($this)
-        {
+        return match ($this) {
             self::ALLOWED, self::FORBIDDEN => '=',
             self::INVERSE => '='
         };
@@ -19,8 +18,7 @@ enum AffiliationType
 
     public function value() : string
     {
-        return match ($this)
-        {
+        return match ($this) {
             self::ALLOWED => 'allowed',
             self::FORBIDDEN => 'forbidden',
             self::INVERSE => 'inverse'

--- a/src/Enums/AffiliationType.php
+++ b/src/Enums/AffiliationType.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Seatplus\Auth\Enums;
+
+enum AffiliationType
+{
+    case ALLOWED;
+    case INVERSE;
+    case FORBIDDEN;
+
+    public function operator() : string
+    {
+        return match ($this)
+        {
+            self::ALLOWED, self::FORBIDDEN => '=',
+            self::INVERSE => '='
+        };
+    }
+
+    public function value() : string
+    {
+        return match ($this)
+        {
+            self::ALLOWED => 'allowed',
+            self::FORBIDDEN => 'forbidden',
+            self::INVERSE => 'inverse'
+        };
+    }
+}

--- a/src/Helpers/helpers.php
+++ b/src/Helpers/helpers.php
@@ -26,6 +26,9 @@
 
 use Seatplus\Auth\Actions\GetAffiliatedIdsByPermissionArray;
 
+/**
+ * @deprecated deprecated since version 2.0
+ */
 if (! function_exists('getAffiliatedIdsByClass')) {
 
     /**
@@ -34,6 +37,7 @@ if (! function_exists('getAffiliatedIdsByClass')) {
      * @param  string  $class
      * @param  string  $role
      * @return array
+     * @deprecated deprecated since version 2.0
      */
     function getAffiliatedIdsByClass(string $class, string $role = ''): array
     {
@@ -43,6 +47,9 @@ if (! function_exists('getAffiliatedIdsByClass')) {
     }
 }
 
+/**
+ * @deprecated deprecated since version 2.0
+ */
 if (! function_exists('getAffiliatedIdsByPermission')) {
 
     /**
@@ -51,6 +58,7 @@ if (! function_exists('getAffiliatedIdsByPermission')) {
      * @param  string  $class
      * @param  string  $role
      * @return array
+     * @deprecated deprecated since version 2.0
      */
     function getAffiliatedIdsByPermission(string $permission, string $role = ''): array
     {

--- a/src/Models/Permissions/Affiliation.php
+++ b/src/Models/Permissions/Affiliation.php
@@ -64,7 +64,7 @@ class Affiliation extends Model
 
     public function role()
     {
-        return $this->belongsTo(Role::class, 'id', 'role_id');
+        return $this->belongsTo(Role::class, 'role_id', 'id');
     }
 
     public function getAffiliatedIdsAttribute(): Collection

--- a/src/Traits/HasAffiliated.php
+++ b/src/Traits/HasAffiliated.php
@@ -1,0 +1,225 @@
+<?php
+
+namespace Seatplus\Auth\Traits;
+
+
+
+use Illuminate\Contracts\Database\Eloquent\Builder;
+use Illuminate\Database\Query\JoinClause;
+use Illuminate\Support\Facades\DB;
+use Seatplus\Auth\Enums\AffiliationType;
+use Seatplus\Auth\Models\AccessControl\AclAffiliation;
+use Seatplus\Auth\Models\Permissions\Affiliation;
+use Seatplus\Auth\Models\Permissions\Permission;
+use Seatplus\Auth\Models\Permissions\Role;
+use Seatplus\Auth\Models\User;
+use Seatplus\Eveapi\Models\Alliance\AllianceInfo;
+use Seatplus\Eveapi\Models\Character\CharacterAffiliation;
+use Seatplus\Eveapi\Models\Character\CharacterInfo;
+use Seatplus\Eveapi\Models\Corporation\CorporationInfo;
+
+trait HasAffiliated
+{
+
+    private User $user;
+    private Builder $affiliation;
+    private string $permission;
+
+    public function scopeAffiliatedCharacters(Builder $query, string $column, null|string $permission = null)
+    {
+        throw_if(auth()->guest(), 'Unauthenticated');
+
+        if($this->getUser()->can('superuser')) {
+            return $query;
+        }
+
+        $this->setPermission($permission);
+
+        $affiliated =
+
+        $character_affiliations = $this->getOwnedCharacterAffiliations()
+            ->union($this->getAffiliatedCharacterAffiliations())
+        ;
+
+        return $query->joinSub($character_affiliations, 'character_affiliations', fn (JoinClause $join) => $join
+            ->on($this->getTable() . ".$column", '=', 'character_affiliations.character_id')
+        );
+        /*return $query->when(!auth()->guest(), fn (Builder $query) => $query
+            ->join('character_users', fn (JoinClause $join) => $join
+                ->on($this->getTable() . ".$column", '=', 'character_users.character_id')
+                ->where('user_id', auth()->user()->getAuthIdentifier())
+            )
+        );*/
+    }
+
+    private function getOwnedCharacterAffiliations() : Builder
+    {
+        return CharacterAffiliation::query()
+            ->join('character_users', fn (JoinClause $join) => $join
+                ->on('character_affiliations.character_id', '=', 'character_users.character_id')
+                ->where('user_id', $this->getUser()->getAuthIdentifier())
+            )
+            ->select('character_affiliations.*');
+    }
+
+    private function convertToPermissionString(string $permission) : string
+    {
+
+        if(class_exists($permission)) {
+            return config('eveapi.permissions.' . $permission) ?? $permission;
+        }
+
+        return $permission;
+    }
+
+    private function getAffiliatedCharacterAffiliations() : Builder
+    {
+        $this->createAffiliation();
+
+        $allowed =  $this->getAllowedAffiliatedCharacterAffiliations();
+        $inverted = $this->getInvertedAffiliatedCharacterAffiliations();
+        $forbidden = $this->getForbiddenAffiliatedCharacterAffiliations();
+
+        //dd($forbidden->select('character_id')->get()->dump());
+
+        return $allowed
+            ->union($inverted)
+            //->get()->dd($forbidden->get())
+            /*->whereNotIn('character_id', fn($query) => $query
+                ->fromSub($forbidden->select('character_id'), 'forbidden_affiliations')
+                ->select('forbidden_affiliations.character_id')
+            )*/
+            ->whereNot(fn($query) => $query
+                ->select('character_affiliations.character_id')
+                ->fromSub($forbidden->select('character_id'), 'forbidden_affiliations')
+                ->whereColumn('forbidden_affiliations.character_id', 'character_affiliations.character_id')
+            )
+            /*->leftJoinSub($forbidden->select('character_id'), 'forbidden_affiliations', fn(JoinClause $join) => $join->
+                //on('forbidden_affiliations.character_id', '=', 'character_affiliations.character_id') // r.value = l.value
+                on('character_affiliations.character_id', '=', 'forbidden_affiliations.character_id')
+                //->whereNull('forbidden_affiliations.character_id')
+                ->get()->dd()
+            )*/
+            ->select('character_affiliations.*')
+            ->get()->dd()
+            //->select('character_affiliations.*')
+            ;
+    }
+
+    private function getUser(): User
+    {
+       if(!isset($this->user)) {
+           $this->user = auth()->user();
+       }
+
+        return $this->user;
+    }
+
+    private function getAllowedAffiliatedCharacterAffiliations() : Builder
+    {
+
+        $type = AffiliationType::ALLOWED;
+        $alias = sprintf('%s_entities', $type->value());
+
+        return CharacterAffiliation::query()
+            ->joinSub(
+                $this->getAffiliation()->where('type', $type->value()),
+                $alias,
+                fn (JoinClause $join) => $this->joinAffiliatedCharacterAffiliations($join, $alias)
+            )
+            ->select('character_affiliations.*');
+    }
+
+    private function getInvertedAffiliatedCharacterAffiliations() : Builder
+    {
+
+        $type = AffiliationType::INVERSE;
+        $alias = sprintf('%s_entities', $type->value());
+
+        $affiliation = $this->getAffiliation()->where('type', $type->value());
+
+        return CharacterAffiliation::query()
+            ->when(
+                $affiliation->count(),
+                fn(Builder $query) => $query
+                    ->leftJoinSub(
+                        $affiliation,
+                        $alias,
+                        fn (JoinClause $join) => $this->joinAffiliatedCharacterAffiliations($join, $alias)
+                    )
+                    ->whereNull("$alias.affiliatable_id")
+                ,
+                fn (Builder $query) => $query->whereNull('character_id')
+            )
+            ->select('character_affiliations.*');
+    }
+
+    private function getForbiddenAffiliatedCharacterAffiliations() : Builder
+    {
+
+        $type = AffiliationType::FORBIDDEN;
+        $alias = sprintf('%s_entities', $type->value());
+
+        $affiliation = $this->getAffiliation()->where('type', $type->value());
+
+        return CharacterAffiliation::query()
+            ->when(
+                $affiliation->count(),
+                fn(Builder $query) => $query
+                    ->joinSub(
+                        $affiliation,
+                        $alias,
+                        fn (JoinClause $join) => $this->joinAffiliatedCharacterAffiliations($join, $alias)
+                    )
+                ,
+                fn (Builder $query) => $query->whereNull('character_id')
+            );
+    }
+
+    private function joinAffiliatedCharacterAffiliations(JoinClause $join, string $alias) : JoinClause
+    {
+        return $join
+            ->on('character_affiliations.character_id', '=', "$alias.affiliatable_id")->where("$alias.affiliatable_type", CharacterInfo::class)
+            ->orOn('character_affiliations.corporation_id', '=', "$alias.affiliatable_id")->where("$alias.affiliatable_type", CorporationInfo::class)
+            ->orOn('character_affiliations.alliance_id', '=', "$alias.affiliatable_id")->where("$alias.affiliatable_type", AllianceInfo::class);
+    }
+
+    /**
+     * @return Builder
+     */
+    public function getAffiliation(): Builder
+    {
+        return clone $this->affiliation;
+    }
+
+    public function createAffiliation(): void
+    {
+        $this->affiliation = Affiliation::query()
+            ->whereRelation('role.permissions', 'name', $this->getPermission())
+            ->whereRelation('role.members', 'user_id', $this->getUser()->getAuthIdentifier());
+    }
+
+    /**
+     * @return string
+     */
+    public function getPermission(): string
+    {
+        return $this->permission;
+    }
+
+    /**
+     * @param string|null $permission
+     */
+    public function setPermission(?string $permission): void
+    {
+        if(is_null($permission)) {
+            $permission = get_class($this);
+        }
+
+        $permission = $this->convertToPermissionString($permission);
+
+        $this->permission = $permission;
+    }
+
+
+}

--- a/src/Traits/HasAffiliated.php
+++ b/src/Traits/HasAffiliated.php
@@ -5,19 +5,16 @@ namespace Seatplus\Auth\Traits;
 
 
 use Illuminate\Contracts\Database\Eloquent\Builder;
+use Illuminate\Database\Query\Builder as QueryBuilder;
 use Illuminate\Database\Query\JoinClause;
 use Illuminate\Support\Facades\DB;
 use Seatplus\Auth\Enums\AffiliationType;
-use Seatplus\Auth\Models\AccessControl\AclAffiliation;
 use Seatplus\Auth\Models\Permissions\Affiliation;
-use Seatplus\Auth\Models\Permissions\Permission;
-use Seatplus\Auth\Models\Permissions\Role;
 use Seatplus\Auth\Models\User;
 use Seatplus\Eveapi\Models\Alliance\AllianceInfo;
 use Seatplus\Eveapi\Models\Character\CharacterAffiliation;
 use Seatplus\Eveapi\Models\Character\CharacterInfo;
 use Seatplus\Eveapi\Models\Corporation\CorporationInfo;
-use function Pest\Laravel\get;
 
 trait HasAffiliated
 {
@@ -39,35 +36,16 @@ trait HasAffiliated
         $character_affiliations = $this->getOwnedCharacterAffiliations()
             ->union($this->getAffiliatedCharacterAffiliations());
 
-        $forbidden = $this->getForbiddenAffiliatedCharacterAffiliations()
-           /* ->leftJoinSub(
-                $this->getOwnedCharacterAffiliations(),
-                'owned_affiliations',
-                function (JoinClause $join) {
-                    $join->on('')
-                }
-            )*/
-        ;
+        $forbidden = $this->getForbiddenAffiliatedCharacterAffiliations();
 
         return $query->joinSub($character_affiliations, 'character_affiliations', fn (JoinClause $join) => $join
             ->on($this->getTable() . ".$column", '=', 'character_affiliations.character_id')
         )
-            //->get()->dd()
-            ->whereNotIn('character_id', fn(\Illuminate\Database\Query\Builder $query) => $query
-                ->fromSub($forbidden, 'helper')
-                ->select('helper.character_id')
+            ->whereNotIn('character_id', fn(QueryBuilder $query) => $query
+                ->fromSub($forbidden, 'forbidden_characters')
+                ->select('forbidden_characters.character_id')
             )
-            ->select($this->getTable() . ".*")
-            ;
-
-        //->get()->dd('test')
-
-        /*return $query->when(!auth()->guest(), fn (Builder $query) => $query
-            ->join('character_users', fn (JoinClause $join) => $join
-                ->on($this->getTable() . ".$column", '=', 'character_users.character_id')
-                ->where('user_id', auth()->user()->getAuthIdentifier())
-            )
-        );*/
+            ->select($this->getTable() . ".*");
     }
 
     private function getOwnedCharacterAffiliations() : Builder
@@ -92,49 +70,13 @@ trait HasAffiliated
 
     private function getAffiliatedCharacterAffiliations() : Builder
     {
-        $this->createAffiliation();
 
         $allowed =  $this->getAllowedAffiliatedCharacterAffiliations();
         $inverted = $this->getInvertedAffiliatedCharacterAffiliations();
-        $forbidden = $this->getForbiddenAffiliatedCharacterAffiliations()->select('character_id');
 
-        /*return $forbidden
-            ->rightJoinSub(
-                $allowed->union($inverted),
-                'not_forbidden_entities',
-                fn(JoinClause $join) => $join->on('not_forbidden_entities.character_id', '=', 'character_affiliations.character_id') // r.value = l.value
-            )
-            ->when($forbidden->count(), fn($query) => $query->whereNull('type') )
-            ->select('not_forbidden_entities.*');*/
-
-        $combined =  $allowed
+        return $allowed
             ->union($inverted)
-        ;
-
-        return $combined
-            //->get()->dd()
-            ->whereNotIn('character_id', fn(\Illuminate\Database\Query\Builder $query) => $query
-                ->fromSub($forbidden, 'helper')
-                ->select('helper.character_id')
-                //->get()->dd('test')
-            )
-            ->select('character_affiliations.*')
-            //->get()->dd()
-            ;
-
-            /*->whereNotIn('character_id', function ($query) use ($forbidden) {
-
-                $type = AffiliationType::INVERSE;
-                $alias = sprintf('%s_entities', $type->value());
-
-                $affiliation = $this->getAffiliation()->where('type', $type->value());
-
-                $query->select('helper.character_id')
-                    ->fromSub($forbidden, 'helper');
-                    //->where(fn($query) => $query->where('helper.affiliatable_type', CharacterInfo::class)->whereColumn('helper.affiliatable_id', 'character_affiliations.character_id'))
-                    //->orWhere(fn($query) => $query->where('helper.affiliatable_type', CharacterInfo::class)->whereColumn('helper.affiliatable_id', 'character_affiliations.corporation_id'))
-                    //->orWhere(fn($query) => $query->where('helper.affiliatable_type', CharacterInfo::class)->whereColumn('helper.affiliatable_id', 'character_affiliations.alliance_id'));
-            });*/
+            ->select('character_affiliations.*');
 
     }
 
@@ -194,25 +136,12 @@ trait HasAffiliated
         $type = AffiliationType::FORBIDDEN;
         $alias = sprintf('%s_entities', $type->value());
 
-        /*$affiliation = $this->getOwnedCharacterAffiliations()
-            //->get()->dd('forbidden')
-            ->get()->dd()
-            ;*/
-
         $affiliation = $this->getAffiliation()->where('type', $type->value())
-            ->whereNotExists(fn(\Illuminate\Database\Query\Builder $query) => $query
+            ->whereNotExists(fn(QueryBuilder $query) => $query
                 ->select(DB::raw(1))
                 ->fromSub($this->getOwnedCharacterAffiliations(), 'owned')
                 ->whereColumn('affiliations.affiliatable_id', 'owned.character_id')
-                ->orWhereColumn('affiliations.affiliatable_id', 'owned.corporation_id')
-                ->orWhereColumn('affiliations.affiliatable_id', 'owned.alliance_id')
             )
-            /*->leftJoinSub(
-                $this->getOwnedCharacterAffiliations(),
-                'owned_entities',
-                fn(JoinClause $join) => $this->joinAffiliatedCharacterAffiliations($join, 'owned_entities')
-            )*/
-            //->get()->dd()
         ;
 
         return CharacterAffiliation::query()

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -4,9 +4,11 @@ use Faker\Factory;
 use Illuminate\Support\Facades\Event;
 use Laravel\Socialite\Two\User as SocialiteUser;
 use Seatplus\Auth\Containers\EveUser;
+use Seatplus\Auth\Models\Permissions\Permission;
 use Seatplus\Eveapi\Models\Corporation\CorporationInfo;
 use Seatplus\Eveapi\Models\RefreshToken;
 use Seatplus\Eveapi\Models\SsoScopes;
+use Spatie\Permission\PermissionRegistrar;
 
 /*
 |--------------------------------------------------------------------------
@@ -118,4 +120,18 @@ function createEveUser(int $character_id = null, string $character_owner_hash = 
         'expiresIn' => $faker->numberBetween(1, 20),
         'user' => ['user'],
     ]);
+}
+
+function assignPermissionToTestUser(array|string $permission_strings)
+{
+    $permission_strings = is_array($permission_strings) ? $permission_strings : [$permission_strings];
+
+    foreach ($permission_strings as $string) {
+        $permission = Permission::findOrCreate($string);
+
+        test()->test_user->givePermissionTo($permission);
+    }
+
+    // now re-register all the roles and permissions
+    app()->make(PermissionRegistrar::class)->registerPermissions();
 }

--- a/tests/Stubs/Assets.php
+++ b/tests/Stubs/Assets.php
@@ -2,14 +2,10 @@
 
 namespace Seatplus\Auth\Tests\Stubs;
 
-
 use Seatplus\Auth\Traits\HasAffiliated;
 use Seatplus\Eveapi\Models\Assets\Asset;
 
-
 class Assets extends Asset
 {
-
     use HasAffiliated;
-
 }

--- a/tests/Stubs/Assets.php
+++ b/tests/Stubs/Assets.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Seatplus\Auth\Tests\Stubs;
+
+
+use Seatplus\Auth\Traits\HasAffiliated;
+use Seatplus\Eveapi\Models\Assets\Asset;
+
+
+class Assets extends Asset
+{
+
+    use HasAffiliated;
+
+}

--- a/tests/Unit/Trait/TraitTest.php
+++ b/tests/Unit/Trait/TraitTest.php
@@ -1,0 +1,227 @@
+<?php
+
+use Seatplus\Auth\Models\Permissions\Affiliation;
+use Seatplus\Auth\Tests\Stubs\Assets;
+use Seatplus\Eveapi\Models\Alliance\AllianceInfo;
+use Seatplus\Eveapi\Models\Character\CharacterInfo;
+use Seatplus\Auth\Models\Permissions\Permission;
+use Seatplus\Auth\Models\Permissions\Role;
+use Seatplus\Eveapi\Models\Corporation\CorporationInfo;
+
+beforeEach(function () {
+    test()->role = Role::create(['name' => faker()->name]);
+    test()->permission = Permission::create(['name' => faker()->company]);
+
+    test()->role->givePermissionTo(test()->permission);
+    test()->role->activateMember(test()->test_user);
+
+    \Illuminate\Support\Facades\Queue::fake();
+
+    expect(Assets::all())->toHaveCount(0);
+
+    test()->secondary_character = createAsset()->assetable;
+    test()->tertiary_character = createAsset()->assetable;
+
+    expect(Assets::all())->toHaveCount(2);
+
+});
+
+it('trows Unauthenticated exception if used without a session', function () {
+    $assets = Assets::query()
+        ->affiliatedCharacters('assetable_id')
+        ->get();
+})->throws('Unauthenticated');
+
+it('returns owned assets', function () {
+
+    createAsset(test()->test_character->character_id);
+
+    expect(Assets::all())->toHaveCount(3);
+
+    // do the same for test_user
+    test()->actingAs(test()->test_user);
+
+    $assets = Assets::query()
+        ->affiliatedCharacters('assetable_id')
+        ->get();
+
+    expect($assets)->toHaveCount(1);
+
+});
+
+it('return all assets for superuser', function () {
+
+    // test to only have 2 (2nd and 3rd character) assets
+    expect(Assets::all())->toHaveCount(2);
+
+    test()->assignPermissionToTestUser('superuser');
+
+    expect(test()->test_user->can('superuser'))->toBeTrue();
+
+    test()->actingAs(test()->test_user);
+
+    $assets = Assets::query()
+        ->affiliatedCharacters('assetable_id')
+        ->get();
+
+    expect($assets)->toHaveCount(2);
+
+});
+
+it('returns assets of allowed and own character', function () {
+
+    createAsset(test()->test_character->character_id);
+
+    // test to have test_character, 2nd and 3rd character assets
+    expect(Assets::all())->toHaveCount(3);
+
+    test()->createAffiliation(
+        test()->secondary_character->character_id,
+        CharacterInfo::class,
+        'allowed'
+    );
+
+    test()->actingAs(test()->test_user);
+
+    $assets = Assets::query()
+        ->affiliatedCharacters('assetable_id', test()->permission->name)
+        ->get();
+
+    expect($assets)->toHaveCount(2);
+
+});
+
+it('returns assets of allowed entities', function (int $affiliatable_id, string $affiliatable_type) {
+
+    // test to only have 2 (2nd and 3rd character) assets
+    expect(Assets::all())->toHaveCount(2);
+
+    test()->createAffiliation(
+        $affiliatable_id,
+        $affiliatable_type,
+        'allowed'
+    );
+
+    test()->actingAs(test()->test_user);
+
+    $assets = Assets::query()
+        ->affiliatedCharacters('assetable_id', test()->permission->name)
+        ->get();
+
+    expect($assets)->toHaveCount(1);
+
+})->with([
+    [fn() => test()->secondary_character->character_id, CharacterInfo::class],
+    [fn() => test()->secondary_character->corporation->corporation_id, CorporationInfo::class],
+    [fn() => test()->secondary_character->corporation->alliance_id, AllianceInfo::class],
+]);
+
+it('returns assets of inverted entities', function (int $affiliatable_id, string $affiliatable_type) {
+
+    // test to only have 2 (2nd and 3rd character) assets
+    expect(Assets::all())->toHaveCount(2);
+
+    test()->createAffiliation(
+        $affiliatable_id,
+        $affiliatable_type,
+        'inverse'
+    );
+
+    test()->actingAs(test()->test_user);
+
+    $assets = Assets::query()
+        ->affiliatedCharacters('assetable_id', test()->permission->name)
+        ->get();
+
+    expect($assets)->toHaveCount(1);
+
+})->with([
+    [fn() => test()->secondary_character->character_id, CharacterInfo::class],
+    [fn() => test()->secondary_character->corporation->corporation_id, CorporationInfo::class],
+    [fn() => test()->secondary_character->corporation->alliance_id, AllianceInfo::class],
+]);
+
+it('returns assets of inverted entities and own', function (int $affiliatable_id, string $affiliatable_type) {
+
+    createAsset(test()->test_character->character_id);
+
+    // test to have 3 assets (test, 2nd and 3rd)
+    expect(Assets::all())->toHaveCount(3);
+
+    test()->createAffiliation(
+        $affiliatable_id,
+        $affiliatable_type,
+        'inverse'
+    );
+
+    test()->actingAs(test()->test_user);
+
+    $assets = Assets::query()
+        ->affiliatedCharacters('assetable_id', test()->permission->name)
+        ->get();
+
+    expect($assets)->toHaveCount(3);
+
+})->with([
+    [fn() => test()->test_character->character_id, CharacterInfo::class],
+    [fn() => test()->test_character->corporation->corporation_id, CorporationInfo::class],
+    [fn() => test()->test_character->corporation->alliance_id, AllianceInfo::class],
+]);
+
+it('does not return assets of forbidden entities', function (int $secondary_id, string $secondary_type, int $tertiary_id, string $tertiary_type) {
+
+
+    // test to only have 2 (2nd and 3rd character) assets
+    expect(Assets::all())->toHaveCount(2);
+
+    // invert secondary, now test user can see tert
+    test()->createAffiliation(
+        $secondary_id,
+        $secondary_type,
+        'inverse'
+    );
+
+    // forbid tert
+    test()->createAffiliation(
+        $tertiary_id,
+        $tertiary_type,
+        'forbidden'
+    );
+
+    expect(Affiliation::all())->toHaveCount(2);
+
+    test()->actingAs(test()->test_user);
+
+    dump($tertiary_id);
+    $assets = Assets::query()
+        ->affiliatedCharacters('assetable_id', test()->permission->name)
+        ->get();
+
+    expect($assets)->toHaveCount(0);
+
+})->with([
+    [fn() => test()->secondary_character->character_id, CharacterInfo::class],
+    [fn() => test()->secondary_character->corporation->corporation_id, CorporationInfo::class],
+    [fn() => test()->secondary_character->corporation->alliance_id, AllianceInfo::class],
+])->with([
+    [fn() => test()->tertiary_character->character_id, CharacterInfo::class],
+    [fn() => test()->tertiary_character->corporation->corporation_id, CorporationInfo::class],
+    [fn() => test()->tertiary_character->corporation->alliance_id, AllianceInfo::class],
+])->only();
+
+function createAffiliation($affiliatable_id, $affiliatable_type, $type = 'allowed'): Affiliation
+{
+    return test()->role->affiliations()->create([
+        'affiliatable_id' => $affiliatable_id,
+        'affiliatable_type' => $affiliatable_type,
+        'type' => $type,
+    ]);
+}
+
+function createAsset(?int $character_id = null) : \Seatplus\Eveapi\Models\Assets\Asset
+{
+    return Assets::factory()->create([
+        'assetable_id' => $character_id ?? CharacterInfo::factory(),
+        'assetable_type' => CharacterInfo::class,
+    ]);
+}

--- a/tests/Unit/Trait/TraitTest.php
+++ b/tests/Unit/Trait/TraitTest.php
@@ -1,11 +1,11 @@
 <?php
 
 use Seatplus\Auth\Models\Permissions\Affiliation;
+use Seatplus\Auth\Models\Permissions\Permission;
+use Seatplus\Auth\Models\Permissions\Role;
 use Seatplus\Auth\Tests\Stubs\Assets;
 use Seatplus\Eveapi\Models\Alliance\AllianceInfo;
 use Seatplus\Eveapi\Models\Character\CharacterInfo;
-use Seatplus\Auth\Models\Permissions\Permission;
-use Seatplus\Auth\Models\Permissions\Role;
 use Seatplus\Eveapi\Models\Corporation\CorporationInfo;
 
 beforeEach(function () {
@@ -23,7 +23,6 @@ beforeEach(function () {
     test()->tertiary_character = createAsset()->assetable;
 
     expect(Assets::all())->toHaveCount(2);
-
 });
 
 it('trows Unauthenticated exception if used without a session', function () {
@@ -33,7 +32,6 @@ it('trows Unauthenticated exception if used without a session', function () {
 })->throws('Unauthenticated');
 
 it('returns owned assets', function () {
-
     createAsset(test()->test_character->character_id);
 
     expect(Assets::all())->toHaveCount(3);
@@ -46,7 +44,6 @@ it('returns owned assets', function () {
         ->get();
 
     expect($assets)->toHaveCount(1);
-
 });
 
 it('return all assets for superuser', function () {
@@ -65,11 +62,9 @@ it('return all assets for superuser', function () {
         ->get();
 
     expect($assets)->toHaveCount(2);
-
 });
 
 it('returns assets of allowed and own character', function () {
-
     createAsset(test()->test_character->character_id);
 
     // test to have test_character, 2nd and 3rd character assets
@@ -88,7 +83,6 @@ it('returns assets of allowed and own character', function () {
         ->get();
 
     expect($assets)->toHaveCount(2);
-
 });
 
 it('returns assets of allowed entities', function (int $affiliatable_id, string $affiliatable_type) {
@@ -109,11 +103,10 @@ it('returns assets of allowed entities', function (int $affiliatable_id, string 
         ->get();
 
     expect($assets)->toHaveCount(1);
-
 })->with([
-    [fn() => test()->secondary_character->character_id, CharacterInfo::class],
-    [fn() => test()->secondary_character->corporation->corporation_id, CorporationInfo::class],
-    [fn() => test()->secondary_character->corporation->alliance_id, AllianceInfo::class],
+    [fn () => test()->secondary_character->character_id, CharacterInfo::class],
+    [fn () => test()->secondary_character->corporation->corporation_id, CorporationInfo::class],
+    [fn () => test()->secondary_character->corporation->alliance_id, AllianceInfo::class],
 ]);
 
 it('returns assets of inverted entities', function (int $affiliatable_id, string $affiliatable_type) {
@@ -134,15 +127,13 @@ it('returns assets of inverted entities', function (int $affiliatable_id, string
         ->get();
 
     expect($assets)->toHaveCount(1);
-
 })->with([
-    [fn() => test()->secondary_character->character_id, CharacterInfo::class],
-    [fn() => test()->secondary_character->corporation->corporation_id, CorporationInfo::class],
-    [fn() => test()->secondary_character->corporation->alliance_id, AllianceInfo::class],
+    [fn () => test()->secondary_character->character_id, CharacterInfo::class],
+    [fn () => test()->secondary_character->corporation->corporation_id, CorporationInfo::class],
+    [fn () => test()->secondary_character->corporation->alliance_id, AllianceInfo::class],
 ]);
 
 it('returns assets of inverted entities and own', function (int $affiliatable_id, string $affiliatable_type) {
-
     createAsset(test()->test_character->character_id);
 
     // test to have 3 assets (test, 2nd and 3rd)
@@ -161,11 +152,10 @@ it('returns assets of inverted entities and own', function (int $affiliatable_id
         ->get();
 
     expect($assets)->toHaveCount(3);
-
 })->with([
-    [fn() => test()->test_character->character_id, CharacterInfo::class],
-    [fn() => test()->test_character->corporation->corporation_id, CorporationInfo::class],
-    [fn() => test()->test_character->corporation->alliance_id, AllianceInfo::class],
+    [fn () => test()->test_character->character_id, CharacterInfo::class],
+    [fn () => test()->test_character->corporation->corporation_id, CorporationInfo::class],
+    [fn () => test()->test_character->corporation->alliance_id, AllianceInfo::class],
 ]);
 
 it('does not return assets of forbidden entities', function (int $secondary_id, string $secondary_type, int $tertiary_id, string $tertiary_type) {
@@ -197,19 +187,17 @@ it('does not return assets of forbidden entities', function (int $secondary_id, 
         ->get();
 
     expect($assets)->toHaveCount(0);
-
 })->with([
-    [fn() => test()->secondary_character->character_id, CharacterInfo::class],
-    [fn() => test()->secondary_character->corporation->corporation_id, CorporationInfo::class],
-    [fn() => test()->secondary_character->corporation->alliance_id, AllianceInfo::class],
+    [fn () => test()->secondary_character->character_id, CharacterInfo::class],
+    [fn () => test()->secondary_character->corporation->corporation_id, CorporationInfo::class],
+    [fn () => test()->secondary_character->corporation->alliance_id, AllianceInfo::class],
 ])->with([
-    [fn() => test()->tertiary_character->character_id, CharacterInfo::class],
-    [fn() => test()->tertiary_character->corporation->corporation_id, CorporationInfo::class],
-    [fn() => test()->tertiary_character->corporation->alliance_id, AllianceInfo::class],
+    [fn () => test()->tertiary_character->character_id, CharacterInfo::class],
+    [fn () => test()->tertiary_character->corporation->corporation_id, CorporationInfo::class],
+    [fn () => test()->tertiary_character->corporation->alliance_id, AllianceInfo::class],
 ]);
 
 it('returns own character id even if it is forbidden', function () {
-
     createAsset(test()->test_character->character_id);
 
     expect(Assets::all())->toHaveCount(3);
@@ -227,24 +215,22 @@ it('returns own character id even if it is forbidden', function () {
         ->get();
 
     expect($assets)->toHaveCount(1);
-
 });
 
 it('runs faster then using the helper', function () {
-
     expect(Assets::all())->toHaveCount(2);
 
     // create 500 characters
     $characters = CharacterInfo::factory()->count(10)->create();
 
-    $characters->each(fn(CharacterInfo $character) => Assets::factory()
+    $characters->each(fn (CharacterInfo $character) => Assets::factory()
         ->count(100)
         ->create([
         'assetable_id' => $character->character_id,
         'assetable_type' => CharacterInfo::class,
     ]));
 
-    expect(Assets::query()->count())->toBe(100*10+2);
+    expect(Assets::query()->count())->toBe(100 * 10 + 2);
 
     test()->createAffiliation(
         test()->secondary_character->corporation->corporation_id,
@@ -274,8 +260,6 @@ it('runs faster then using the helper', function () {
     $time_elapsed_trait = microtime(true) - $start;
 
     expect($time_elapsed_trait)->toBeLessThan($time_elapsed_helper);
-
-
 });
 
 function createAffiliation($affiliatable_id, $affiliatable_type, $type = 'allowed'): Affiliation

--- a/tests/Unit/Trait/TraitTest.php
+++ b/tests/Unit/Trait/TraitTest.php
@@ -1,11 +1,11 @@
 <?php
 
 use Seatplus\Auth\Models\Permissions\Affiliation;
+use Seatplus\Auth\Models\Permissions\Permission;
+use Seatplus\Auth\Models\Permissions\Role;
 use Seatplus\Auth\Tests\Stubs\Assets;
 use Seatplus\Eveapi\Models\Alliance\AllianceInfo;
 use Seatplus\Eveapi\Models\Character\CharacterInfo;
-use Seatplus\Auth\Models\Permissions\Permission;
-use Seatplus\Auth\Models\Permissions\Role;
 use Seatplus\Eveapi\Models\Corporation\CorporationInfo;
 
 beforeEach(function () {
@@ -23,7 +23,6 @@ beforeEach(function () {
     test()->tertiary_character = createAsset()->assetable;
 
     expect(Assets::all())->toHaveCount(2);
-
 });
 
 it('trows Unauthenticated exception if used without a session', function () {
@@ -33,7 +32,6 @@ it('trows Unauthenticated exception if used without a session', function () {
 })->throws('Unauthenticated');
 
 it('returns owned assets', function () {
-
     createAsset(test()->test_character->character_id);
 
     expect(Assets::all())->toHaveCount(3);
@@ -46,7 +44,6 @@ it('returns owned assets', function () {
         ->get();
 
     expect($assets)->toHaveCount(1);
-
 });
 
 it('return all assets for superuser', function () {
@@ -65,11 +62,9 @@ it('return all assets for superuser', function () {
         ->get();
 
     expect($assets)->toHaveCount(2);
-
 });
 
 it('returns assets of allowed and own character', function () {
-
     createAsset(test()->test_character->character_id);
 
     // test to have test_character, 2nd and 3rd character assets
@@ -88,7 +83,6 @@ it('returns assets of allowed and own character', function () {
         ->get();
 
     expect($assets)->toHaveCount(2);
-
 });
 
 it('returns assets of allowed entities', function (int $affiliatable_id, string $affiliatable_type) {
@@ -109,11 +103,10 @@ it('returns assets of allowed entities', function (int $affiliatable_id, string 
         ->get();
 
     expect($assets)->toHaveCount(1);
-
 })->with([
-    [fn() => test()->secondary_character->character_id, CharacterInfo::class],
-    [fn() => test()->secondary_character->corporation->corporation_id, CorporationInfo::class],
-    [fn() => test()->secondary_character->corporation->alliance_id, AllianceInfo::class],
+    [fn () => test()->secondary_character->character_id, CharacterInfo::class],
+    [fn () => test()->secondary_character->corporation->corporation_id, CorporationInfo::class],
+    [fn () => test()->secondary_character->corporation->alliance_id, AllianceInfo::class],
 ]);
 
 it('returns assets of inverted entities', function (int $affiliatable_id, string $affiliatable_type) {
@@ -134,15 +127,13 @@ it('returns assets of inverted entities', function (int $affiliatable_id, string
         ->get();
 
     expect($assets)->toHaveCount(1);
-
 })->with([
-    [fn() => test()->secondary_character->character_id, CharacterInfo::class],
-    [fn() => test()->secondary_character->corporation->corporation_id, CorporationInfo::class],
-    [fn() => test()->secondary_character->corporation->alliance_id, AllianceInfo::class],
+    [fn () => test()->secondary_character->character_id, CharacterInfo::class],
+    [fn () => test()->secondary_character->corporation->corporation_id, CorporationInfo::class],
+    [fn () => test()->secondary_character->corporation->alliance_id, AllianceInfo::class],
 ]);
 
 it('returns assets of inverted entities and own', function (int $affiliatable_id, string $affiliatable_type) {
-
     createAsset(test()->test_character->character_id);
 
     // test to have 3 assets (test, 2nd and 3rd)
@@ -161,11 +152,10 @@ it('returns assets of inverted entities and own', function (int $affiliatable_id
         ->get();
 
     expect($assets)->toHaveCount(3);
-
 })->with([
-    [fn() => test()->test_character->character_id, CharacterInfo::class],
-    [fn() => test()->test_character->corporation->corporation_id, CorporationInfo::class],
-    [fn() => test()->test_character->corporation->alliance_id, AllianceInfo::class],
+    [fn () => test()->test_character->character_id, CharacterInfo::class],
+    [fn () => test()->test_character->corporation->corporation_id, CorporationInfo::class],
+    [fn () => test()->test_character->corporation->alliance_id, AllianceInfo::class],
 ]);
 
 it('does not return assets of forbidden entities', function (int $secondary_id, string $secondary_type, int $tertiary_id, string $tertiary_type) {
@@ -198,15 +188,14 @@ it('does not return assets of forbidden entities', function (int $secondary_id, 
         ->get();
 
     expect($assets)->toHaveCount(0);
-
 })->with([
-    [fn() => test()->secondary_character->character_id, CharacterInfo::class],
-    [fn() => test()->secondary_character->corporation->corporation_id, CorporationInfo::class],
-    [fn() => test()->secondary_character->corporation->alliance_id, AllianceInfo::class],
+    [fn () => test()->secondary_character->character_id, CharacterInfo::class],
+    [fn () => test()->secondary_character->corporation->corporation_id, CorporationInfo::class],
+    [fn () => test()->secondary_character->corporation->alliance_id, AllianceInfo::class],
 ])->with([
-    [fn() => test()->tertiary_character->character_id, CharacterInfo::class],
-    [fn() => test()->tertiary_character->corporation->corporation_id, CorporationInfo::class],
-    [fn() => test()->tertiary_character->corporation->alliance_id, AllianceInfo::class],
+    [fn () => test()->tertiary_character->character_id, CharacterInfo::class],
+    [fn () => test()->tertiary_character->corporation->corporation_id, CorporationInfo::class],
+    [fn () => test()->tertiary_character->corporation->alliance_id, AllianceInfo::class],
 ])->only();
 
 function createAffiliation($affiliatable_id, $affiliatable_type, $type = 'allowed'): Affiliation

--- a/tests/Unit/Trait/TraitTest.php
+++ b/tests/Unit/Trait/TraitTest.php
@@ -230,6 +230,54 @@ it('returns own character id even if it is forbidden', function () {
 
 });
 
+it('runs faster then using the helper', function () {
+
+    expect(Assets::all())->toHaveCount(2);
+
+    // create 500 characters
+    $characters = CharacterInfo::factory()->count(10)->create();
+
+    $characters->each(fn(CharacterInfo $character) => Assets::factory()
+        ->count(100)
+        ->create([
+        'assetable_id' => $character->character_id,
+        'assetable_type' => CharacterInfo::class,
+    ]));
+
+    expect(Assets::query()->count())->toBe(100*10+2);
+
+    test()->createAffiliation(
+        test()->secondary_character->corporation->corporation_id,
+        CorporationInfo::class,
+        'forbidden'
+    );
+
+    test()->actingAs(test()->test_user);
+
+    $start = microtime(true);
+
+    $ids = getAffiliatedIdsByClass(\Seatplus\Eveapi\Models\Assets\Asset::class);
+
+    Assets::query()
+        ->whereIn('assetable_id', $ids)
+        ->get();
+
+    $time_elapsed_helper = microtime(true) - $start;
+
+    // And now the helper
+    $start = microtime(true);
+
+    Assets::query()
+        ->affiliatedCharacters('assetable_id', test()->permission->name)
+        ->get();
+
+    $time_elapsed_trait = microtime(true) - $start;
+
+    expect($time_elapsed_trait)->toBeLessThan($time_elapsed_helper);
+
+
+});
+
 function createAffiliation($affiliatable_id, $affiliatable_type, $type = 'allowed'): Affiliation
 {
     return test()->role->affiliations()->create([

--- a/tests/Unit/Trait/TraitTest.php
+++ b/tests/Unit/Trait/TraitTest.php
@@ -275,8 +275,35 @@ it('runs faster then using the helper', function () {
 
     expect($time_elapsed_trait)->toBeLessThan($time_elapsed_helper);
 
-
 });
+
+it('return corporation owned assets for ($character_role, $corporation_role) ', function (string $character_role, string $corporation_role, bool $can_find_asset) {
+
+    // give test_character corporation role
+    \Seatplus\Eveapi\Models\Character\CharacterRole::factory()->create([
+        'character_id' => test()->test_character->character_id,
+        'roles' => [$character_role]
+    ]);
+
+    //dump(\Seatplus\Eveapi\Models\Character\CharacterRole::where('character_id', test()->test_character->character_id)->get());
+
+    // create corporation asset
+    createAsset(test()->test_character->corporation->corporation_id);
+
+    // query asset
+    test()->actingAs(test()->test_user);
+
+    $assets = Assets::query()
+        ->affiliatedCorporations('assetable_id', test()->permission->name, $corporation_role)
+        ->get();
+
+    expect($assets)->toHaveCount($can_find_asset ? 1 : 0);
+
+})->with([
+    ['Director', 'Director', true],
+    ['Director', 'NoDirector', true],
+    ['NoDirector', 'Director', false],
+]);
 
 function createAffiliation($affiliatable_id, $affiliatable_type, $type = 'allowed'): Affiliation
 {

--- a/tests/Unit/Trait/TraitTest.php
+++ b/tests/Unit/Trait/TraitTest.php
@@ -192,7 +192,6 @@ it('does not return assets of forbidden entities', function (int $secondary_id, 
 
     test()->actingAs(test()->test_user);
 
-    dump($tertiary_id);
     $assets = Assets::query()
         ->affiliatedCharacters('assetable_id', test()->permission->name)
         ->get();
@@ -207,7 +206,29 @@ it('does not return assets of forbidden entities', function (int $secondary_id, 
     [fn() => test()->tertiary_character->character_id, CharacterInfo::class],
     [fn() => test()->tertiary_character->corporation->corporation_id, CorporationInfo::class],
     [fn() => test()->tertiary_character->corporation->alliance_id, AllianceInfo::class],
-])->only();
+]);
+
+it('returns own character id even if it is forbidden', function () {
+
+    createAsset(test()->test_character->character_id);
+
+    expect(Assets::all())->toHaveCount(3);
+
+    test()->createAffiliation(
+        test()->test_character->character_id,
+        CharacterInfo::class,
+        'forbidden'
+    );
+
+    test()->actingAs(test()->test_user);
+
+    $assets = Assets::query()
+        ->affiliatedCharacters('assetable_id', test()->permission->name)
+        ->get();
+
+    expect($assets)->toHaveCount(1);
+
+});
 
 function createAffiliation($affiliatable_id, $affiliatable_type, $type = 'allowed'): Affiliation
 {

--- a/tests/Unit/Trait/TraitTest.php
+++ b/tests/Unit/Trait/TraitTest.php
@@ -1,11 +1,11 @@
 <?php
 
 use Seatplus\Auth\Models\Permissions\Affiliation;
+use Seatplus\Auth\Models\Permissions\Permission;
+use Seatplus\Auth\Models\Permissions\Role;
 use Seatplus\Auth\Tests\Stubs\Assets;
 use Seatplus\Eveapi\Models\Alliance\AllianceInfo;
 use Seatplus\Eveapi\Models\Character\CharacterInfo;
-use Seatplus\Auth\Models\Permissions\Permission;
-use Seatplus\Auth\Models\Permissions\Role;
 use Seatplus\Eveapi\Models\Corporation\CorporationInfo;
 
 beforeEach(function () {
@@ -23,7 +23,6 @@ beforeEach(function () {
     test()->tertiary_character = createAsset()->assetable;
 
     expect(Assets::all())->toHaveCount(2);
-
 });
 
 it('trows Unauthenticated exception if used without a session', function () {
@@ -33,7 +32,6 @@ it('trows Unauthenticated exception if used without a session', function () {
 })->throws('Unauthenticated');
 
 it('returns owned assets', function () {
-
     createAsset(test()->test_character->character_id);
 
     expect(Assets::all())->toHaveCount(3);
@@ -46,7 +44,6 @@ it('returns owned assets', function () {
         ->get();
 
     expect($assets)->toHaveCount(1);
-
 });
 
 it('return all assets for superuser', function () {
@@ -65,11 +62,9 @@ it('return all assets for superuser', function () {
         ->get();
 
     expect($assets)->toHaveCount(2);
-
 });
 
 it('returns assets of allowed and own character', function () {
-
     createAsset(test()->test_character->character_id);
 
     // test to have test_character, 2nd and 3rd character assets
@@ -88,7 +83,6 @@ it('returns assets of allowed and own character', function () {
         ->get();
 
     expect($assets)->toHaveCount(2);
-
 });
 
 it('returns assets of allowed entities', function (int $affiliatable_id, string $affiliatable_type) {
@@ -109,11 +103,10 @@ it('returns assets of allowed entities', function (int $affiliatable_id, string 
         ->get();
 
     expect($assets)->toHaveCount(1);
-
 })->with([
-    [fn() => test()->secondary_character->character_id, CharacterInfo::class],
-    [fn() => test()->secondary_character->corporation->corporation_id, CorporationInfo::class],
-    [fn() => test()->secondary_character->corporation->alliance_id, AllianceInfo::class],
+    [fn () => test()->secondary_character->character_id, CharacterInfo::class],
+    [fn () => test()->secondary_character->corporation->corporation_id, CorporationInfo::class],
+    [fn () => test()->secondary_character->corporation->alliance_id, AllianceInfo::class],
 ]);
 
 it('returns assets of inverted entities', function (int $affiliatable_id, string $affiliatable_type) {
@@ -134,15 +127,13 @@ it('returns assets of inverted entities', function (int $affiliatable_id, string
         ->get();
 
     expect($assets)->toHaveCount(1);
-
 })->with([
-    [fn() => test()->secondary_character->character_id, CharacterInfo::class],
-    [fn() => test()->secondary_character->corporation->corporation_id, CorporationInfo::class],
-    [fn() => test()->secondary_character->corporation->alliance_id, AllianceInfo::class],
+    [fn () => test()->secondary_character->character_id, CharacterInfo::class],
+    [fn () => test()->secondary_character->corporation->corporation_id, CorporationInfo::class],
+    [fn () => test()->secondary_character->corporation->alliance_id, AllianceInfo::class],
 ]);
 
 it('returns assets of inverted entities and own', function (int $affiliatable_id, string $affiliatable_type) {
-
     createAsset(test()->test_character->character_id);
 
     // test to have 3 assets (test, 2nd and 3rd)
@@ -161,11 +152,10 @@ it('returns assets of inverted entities and own', function (int $affiliatable_id
         ->get();
 
     expect($assets)->toHaveCount(3);
-
 })->with([
-    [fn() => test()->test_character->character_id, CharacterInfo::class],
-    [fn() => test()->test_character->corporation->corporation_id, CorporationInfo::class],
-    [fn() => test()->test_character->corporation->alliance_id, AllianceInfo::class],
+    [fn () => test()->test_character->character_id, CharacterInfo::class],
+    [fn () => test()->test_character->corporation->corporation_id, CorporationInfo::class],
+    [fn () => test()->test_character->corporation->alliance_id, AllianceInfo::class],
 ]);
 
 it('does not return assets of forbidden entities', function (int $secondary_id, string $secondary_type, int $tertiary_id, string $tertiary_type) {
@@ -197,19 +187,17 @@ it('does not return assets of forbidden entities', function (int $secondary_id, 
         ->get();
 
     expect($assets)->toHaveCount(0);
-
 })->with([
-    [fn() => test()->secondary_character->character_id, CharacterInfo::class],
-    [fn() => test()->secondary_character->corporation->corporation_id, CorporationInfo::class],
-    [fn() => test()->secondary_character->corporation->alliance_id, AllianceInfo::class],
+    [fn () => test()->secondary_character->character_id, CharacterInfo::class],
+    [fn () => test()->secondary_character->corporation->corporation_id, CorporationInfo::class],
+    [fn () => test()->secondary_character->corporation->alliance_id, AllianceInfo::class],
 ])->with([
-    [fn() => test()->tertiary_character->character_id, CharacterInfo::class],
-    [fn() => test()->tertiary_character->corporation->corporation_id, CorporationInfo::class],
-    [fn() => test()->tertiary_character->corporation->alliance_id, AllianceInfo::class],
+    [fn () => test()->tertiary_character->character_id, CharacterInfo::class],
+    [fn () => test()->tertiary_character->corporation->corporation_id, CorporationInfo::class],
+    [fn () => test()->tertiary_character->corporation->alliance_id, AllianceInfo::class],
 ]);
 
 it('returns own character id even if it is forbidden', function () {
-
     createAsset(test()->test_character->character_id);
 
     expect(Assets::all())->toHaveCount(3);
@@ -227,24 +215,22 @@ it('returns own character id even if it is forbidden', function () {
         ->get();
 
     expect($assets)->toHaveCount(1);
-
 });
 
 it('runs faster then using the helper', function () {
-
     expect(Assets::all())->toHaveCount(2);
 
     // create 500 characters
     $characters = CharacterInfo::factory()->count(10)->create();
 
-    $characters->each(fn(CharacterInfo $character) => Assets::factory()
+    $characters->each(fn (CharacterInfo $character) => Assets::factory()
         ->count(100)
         ->create([
         'assetable_id' => $character->character_id,
         'assetable_type' => CharacterInfo::class,
     ]));
 
-    expect(Assets::query()->count())->toBe(100*10+2);
+    expect(Assets::query()->count())->toBe(100 * 10 + 2);
 
     test()->createAffiliation(
         test()->secondary_character->corporation->corporation_id,
@@ -274,7 +260,6 @@ it('runs faster then using the helper', function () {
     $time_elapsed_trait = microtime(true) - $start;
 
     expect($time_elapsed_trait)->toBeLessThan($time_elapsed_helper);
-
 });
 
 it('return corporation owned assets for ($character_role, $corporation_role) ', function (string $character_role, string $corporation_role, bool $can_find_asset) {
@@ -282,7 +267,7 @@ it('return corporation owned assets for ($character_role, $corporation_role) ', 
     // give test_character corporation role
     \Seatplus\Eveapi\Models\Character\CharacterRole::factory()->create([
         'character_id' => test()->test_character->character_id,
-        'roles' => [$character_role]
+        'roles' => [$character_role],
     ]);
 
     //dump(\Seatplus\Eveapi\Models\Character\CharacterRole::where('character_id', test()->test_character->character_id)->get());
@@ -298,7 +283,6 @@ it('return corporation owned assets for ($character_role, $corporation_role) ', 
         ->get();
 
     expect($assets)->toHaveCount($can_find_asset ? 1 : 0);
-
 })->with([
     ['Director', 'Director', true],
     ['Director', 'NoDirector', true],


### PR DESCRIPTION
This PR introduces the `HasAffiliated` Trait. 

Using the trait allowes to use two query-scopes:

1. `affiliatedCharacters('column`, 'permission')`
2. `affiliatedCorporations('column`, 'permission', 'corporation_role')`

usage
```
// character_id refers the column on Model to filter the results on
Model::query()->affiliatedCharacters('character_id')
``` 