### PR TITLE
chore: auth code quality overhaul (Groups 1-4) — rebase onto 4.x

### DIFF
--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -44,7 +44,7 @@ class UserFactory extends Factory
     public function configure(): UserFactory
     {
         return $this->afterCreating(function (User $user) {
-            $user->character_users()->save(CharacterUser::factory()->make());
+            $user->characterUsers()->save(CharacterUser::factory()->make());
         });
     }
 

--- a/src/AuthenticationServiceProvider.php
+++ b/src/AuthenticationServiceProvider.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * MIT License
  *

--- a/src/Containers/EveUser.php
+++ b/src/Containers/EveUser.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * MIT License
  *

--- a/src/Enums/AffiliationType.php
+++ b/src/Enums/AffiliationType.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Seatplus\Auth\Enums;
 
 enum AffiliationType: string

--- a/src/Enums/RoleMembershipStatus.php
+++ b/src/Enums/RoleMembershipStatus.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Seatplus\Auth\Enums;
 
 enum RoleMembershipStatus: string

--- a/src/Enums/RoleType.php
+++ b/src/Enums/RoleType.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Seatplus\Auth\Enums;
 
 enum RoleType: string

--- a/src/Exceptions/CriteriaNotMetException.php
+++ b/src/Exceptions/CriteriaNotMetException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Seatplus\Auth\Exceptions;
+
+use RuntimeException;
+
+final class CriteriaNotMetException extends RuntimeException
+{
+    public function __construct(string $message = 'User does not meet criteria to join role')
+    {
+        parent::__construct($message);
+    }
+}

--- a/src/Http/Actions/LoginAssetsAction.php
+++ b/src/Http/Actions/LoginAssetsAction.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Seatplus\Auth\Http\Actions;
 
 class LoginAssetsAction

--- a/src/Http/Actions/LogoutAction.php
+++ b/src/Http/Actions/LogoutAction.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Seatplus\Auth\Http\Actions;
 
 use Illuminate\Http\RedirectResponse;

--- a/src/Http/Actions/Roles/AddModeratorRoleAction.php
+++ b/src/Http/Actions/Roles/AddModeratorRoleAction.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Seatplus\Auth\Http\Actions\Roles;
 
 class AddModeratorRoleAction

--- a/src/Http/Actions/Roles/Manual/AddMemberAction.php
+++ b/src/Http/Actions/Roles/Manual/AddMemberAction.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Seatplus\Auth\Http\Actions\Roles\Manual;
 
 class AddMemberAction

--- a/src/Http/Actions/Roles/Manual/RemoveMemberAction.php
+++ b/src/Http/Actions/Roles/Manual/RemoveMemberAction.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Seatplus\Auth\Http\Actions\Roles\Manual;
 
 class RemoveMemberAction

--- a/src/Http/Actions/Roles/Manual/SetMemberAction.php
+++ b/src/Http/Actions/Roles/Manual/SetMemberAction.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Seatplus\Auth\Http\Actions\Roles\Manual;
 
 use Seatplus\Auth\Models\User;

--- a/src/Http/Actions/Roles/OnRequest/ApplyAction.php
+++ b/src/Http/Actions/Roles/OnRequest/ApplyAction.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Seatplus\Auth\Http\Actions\Roles\OnRequest;
 
 use Seatplus\Auth\Models\User;

--- a/src/Http/Actions/Roles/OnRequest/ApproveAction.php
+++ b/src/Http/Actions/Roles/OnRequest/ApproveAction.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Seatplus\Auth\Http\Actions\Roles\OnRequest;
 
 use Seatplus\Auth\Models\User;

--- a/src/Http/Actions/Roles/OnRequest/ApproveAction.php
+++ b/src/Http/Actions/Roles/OnRequest/ApproveAction.php
@@ -10,10 +10,8 @@ use Seatplus\Auth\Services\Roles\BaseRoleService;
 class ApproveAction
 {
     public function __construct(
-        private ?BaseRoleService $baseRoleService = null
-    ) {
-        $this->baseRoleService = $baseRoleService ?? new BaseRoleService;
-    }
+        private readonly BaseRoleService $baseRoleService = new BaseRoleService,
+    ) {}
 
     /**
      * @throws \Throwable

--- a/src/Http/Actions/Roles/OnRequest/DenyAction.php
+++ b/src/Http/Actions/Roles/OnRequest/DenyAction.php
@@ -10,10 +10,8 @@ use Seatplus\Auth\Services\Roles\BaseRoleService;
 class DenyAction
 {
     public function __construct(
-        private ?BaseRoleService $baseRoleService = null
-    ) {
-        $this->baseRoleService = $baseRoleService ?? new BaseRoleService;
-    }
+        private readonly BaseRoleService $baseRoleService = new BaseRoleService,
+    ) {}
 
     /**
      * @throws \Throwable

--- a/src/Http/Actions/Roles/OnRequest/DenyAction.php
+++ b/src/Http/Actions/Roles/OnRequest/DenyAction.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Seatplus\Auth\Http\Actions\Roles\OnRequest;
 
 use Seatplus\Auth\Models\User;

--- a/src/Http/Actions/Roles/OnRequest/OptOutAction.php
+++ b/src/Http/Actions/Roles/OnRequest/OptOutAction.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Seatplus\Auth\Http\Actions\Roles\OnRequest;
 
 use Seatplus\Auth\Models\User;

--- a/src/Http/Actions/Roles/OptIn/JoinAction.php
+++ b/src/Http/Actions/Roles/OptIn/JoinAction.php
@@ -10,10 +10,8 @@ use Seatplus\Auth\Services\Roles\BaseRoleService;
 class JoinAction
 {
     public function __construct(
-        private ?BaseRoleService $baseRoleService = null
-    ) {
-        $this->baseRoleService = $baseRoleService ?? new BaseRoleService;
-    }
+        private readonly BaseRoleService $baseRoleService = new BaseRoleService,
+    ) {}
 
     /**
      * @throws \Throwable

--- a/src/Http/Actions/Roles/OptIn/JoinAction.php
+++ b/src/Http/Actions/Roles/OptIn/JoinAction.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Seatplus\Auth\Http\Actions\Roles\OptIn;
 
 use Seatplus\Auth\Models\User;

--- a/src/Http/Actions/Roles/OptIn/LeaveAction.php
+++ b/src/Http/Actions/Roles/OptIn/LeaveAction.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Seatplus\Auth\Http\Actions\Roles\OptIn;
 
 use Seatplus\Auth\Models\User;

--- a/src/Http/Actions/Roles/OptIn/LeaveAction.php
+++ b/src/Http/Actions/Roles/OptIn/LeaveAction.php
@@ -10,10 +10,8 @@ use Seatplus\Auth\Services\Roles\BaseRoleService;
 class LeaveAction
 {
     public function __construct(
-        private ?BaseRoleService $baseRoleService = null
-    ) {
-        $this->baseRoleService = $baseRoleService ?? new BaseRoleService;
-    }
+        private readonly BaseRoleService $baseRoleService = new BaseRoleService,
+    ) {}
 
     /**
      * @throws \Throwable

--- a/src/Http/Actions/Roles/RemoveModeratorRoleAction.php
+++ b/src/Http/Actions/Roles/RemoveModeratorRoleAction.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Seatplus\Auth\Http\Actions\Roles;
 
 class RemoveModeratorRoleAction

--- a/src/Http/Actions/Roles/SetModeratorAction.php
+++ b/src/Http/Actions/Roles/SetModeratorAction.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Seatplus\Auth\Http\Actions\Roles;
 
 use Seatplus\Auth\Models\User;

--- a/src/Http/Actions/Sso/FindOrCreateUserAction.php
+++ b/src/Http/Actions/Sso/FindOrCreateUserAction.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * MIT License
  *

--- a/src/Http/Actions/Sso/FindOrCreateUserAction.php
+++ b/src/Http/Actions/Sso/FindOrCreateUserAction.php
@@ -99,7 +99,7 @@ class FindOrCreateUserAction
 
         // First let's check if this is the only character within the user group
         if ($this->character_user->user->characters->count() < 2) {
-            // reset main_character name as this single user account went stale
+            // reset mainCharacter name as this single user account went stale
             $this->character_user->user->main_character_id = null;
             $this->character_user->user->save();
         }

--- a/src/Http/Actions/Sso/UpdateRefreshTokenAction.php
+++ b/src/Http/Actions/Sso/UpdateRefreshTokenAction.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * MIT License
  *

--- a/src/Http/Controllers/Auth/CallbackController.php
+++ b/src/Http/Controllers/Auth/CallbackController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Seatplus\Auth\Http\Controllers\Auth;
 
 use Illuminate\Http\RedirectResponse;

--- a/src/Http/Controllers/Auth/RedirectSSOController.php
+++ b/src/Http/Controllers/Auth/RedirectSSOController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * MIT License
  *

--- a/src/Http/Controllers/Auth/StepUpController.php
+++ b/src/Http/Controllers/Auth/StepUpController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * MIT License
  *

--- a/src/Http/Controllers/Controller.php
+++ b/src/Http/Controllers/Controller.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * MIT License
  *

--- a/src/Http/Controllers/SwitchMainCharacterController.php
+++ b/src/Http/Controllers/SwitchMainCharacterController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * MIT License
  *

--- a/src/Http/Controllers/SwitchMainCharacterController.php
+++ b/src/Http/Controllers/SwitchMainCharacterController.php
@@ -36,7 +36,7 @@ class SwitchMainCharacterController extends Controller
 {
     public function __invoke(int $new_character_id): RedirectResponse
     {
-        $user = User::whereHas('character_users', fn (Builder $query) => $query->where('character_id', $new_character_id))
+        $user = User::whereHas('characterUsers', fn (Builder $query) => $query->where('character_id', $new_character_id))
             ->firstWhere('id', auth()->user()->getAuthIdentifier());
 
         abort_if(is_null($user), 403);

--- a/src/Http/Middleware/CheckAuthorization.php
+++ b/src/Http/Middleware/CheckAuthorization.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * MIT License
  *

--- a/src/Http/Middleware/CheckAuthorization.php
+++ b/src/Http/Middleware/CheckAuthorization.php
@@ -30,6 +30,7 @@ namespace Seatplus\Auth\Http\Middleware;
 
 use Closure;
 use Illuminate\Http\Request;
+use InvalidArgumentException;
 use Seatplus\Auth\Models\User;
 use Seatplus\Auth\Services\Permissions\CanUserService;
 use Seatplus\Auth\Services\Permissions\DTO\ValidateIdsDTO;
@@ -44,7 +45,13 @@ class CheckAuthorization
     {
         /** @var User $user */
         $user = auth()->user();
-        $ids_dto = ValidateIdsDTO::fromRequest($request);
+
+        try {
+            $ids_dto = ValidateIdsDTO::fromRequest($request);
+        } catch (InvalidArgumentException) {
+            abort(403);
+        }
+
         $permissions = explode('|', $permissions);
         $corporation_role = explode('|', (string) $corporation_role);
 

--- a/src/Http/Middleware/CheckAuthorization.php
+++ b/src/Http/Middleware/CheckAuthorization.php
@@ -37,10 +37,8 @@ use Seatplus\Auth\Services\Permissions\DTO\ValidateIdsDTO;
 class CheckAuthorization
 {
     public function __construct(
-        private ?CanUserService $canUserService = null
-    ) {
-        $this->canUserService ??= new CanUserService;
-    }
+        private readonly CanUserService $canUserService = new CanUserService,
+    ) {}
 
     public function handle(Request $request, Closure $next, string $permissions, ?string $corporation_role = null): mixed
     {

--- a/src/Http/Middleware/CheckRequiredScopes.php
+++ b/src/Http/Middleware/CheckRequiredScopes.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * MIT License
  *
@@ -40,7 +42,7 @@ class CheckRequiredScopes
         $this->isUserCompliantService ??= new IsUserCompliantService;
     }
 
-    public function handle(Request $request, Closure $next) // @pest-ignore-type
+    public function handle(Request $request, Closure $next): Response
     {
 
         return $this->isUserCompliantService->check($request->user())

--- a/src/Http/Middleware/CheckRequiredScopes.php
+++ b/src/Http/Middleware/CheckRequiredScopes.php
@@ -37,10 +37,8 @@ use Symfony\Component\HttpFoundation\Response;
 class CheckRequiredScopes
 {
     public function __construct(
-        private ?IsUserCompliantService $isUserCompliantService = null,
-    ) {
-        $this->isUserCompliantService ??= new IsUserCompliantService;
-    }
+        private readonly IsUserCompliantService $isUserCompliantService = new IsUserCompliantService,
+    ) {}
 
     public function handle(Request $request, Closure $next): Response
     {

--- a/src/Http/Requests/RoleRequest.php
+++ b/src/Http/Requests/RoleRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Seatplus\Auth\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;

--- a/src/Jobs/RoleMemberSync.php
+++ b/src/Jobs/RoleMemberSync.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * MIT License
  *

--- a/src/Jobs/RoleMemberSync.php
+++ b/src/Jobs/RoleMemberSync.php
@@ -41,10 +41,8 @@ class RoleMemberSync implements ShouldBeUnique, ShouldQueue
     public int $tries = 1;
 
     public function __construct(
-        private ?BaseRoleService $service = null
-    ) {
-        $this->service = $service ?? new BaseRoleService;
-    }
+        private readonly BaseRoleService $service = new BaseRoleService,
+    ) {}
 
     /**
      * Assign this job a tag so that Horizon can categorize and allow

--- a/src/Listeners/ReactOnFreshRefreshToken.php
+++ b/src/Listeners/ReactOnFreshRefreshToken.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * MIT License
  *

--- a/src/Listeners/UpdatingRefreshTokenListener.php
+++ b/src/Listeners/UpdatingRefreshTokenListener.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * MIT License
  *

--- a/src/Models/AccessControl/RoleMembership.php
+++ b/src/Models/AccessControl/RoleMembership.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Seatplus\Auth\Models\AccessControl;
 
 use Illuminate\Database\Eloquent\Attributes\Fillable;
@@ -32,11 +34,13 @@ class RoleMembership extends Model
         ];
     }
 
+    /** @return BelongsTo<Role, $this> */
     public function role(): BelongsTo
     {
         return $this->belongsTo(Role::class, 'role_id');
     }
 
+    /** @return MorphTo<Model, $this> */
     public function entity(): MorphTo
     {
         return $this->morphTo();

--- a/src/Models/CharacterUser.php
+++ b/src/Models/CharacterUser.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * MIT License
  *

--- a/src/Models/Permissions/Affiliation.php
+++ b/src/Models/Permissions/Affiliation.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * MIT License
  *

--- a/src/Models/Permissions/Permission.php
+++ b/src/Models/Permissions/Permission.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * MIT License
  *

--- a/src/Models/Permissions/Role.php
+++ b/src/Models/Permissions/Role.php
@@ -53,7 +53,7 @@ class Role extends SpatieRole
     }
 
     /** @return HasMany<RoleMembership, $this> */
-    public function role_memberships(): HasMany
+    public function roleMemberships(): HasMany
     {
         return $this->hasMany(RoleMembership::class, 'role_id');
     }

--- a/src/Models/Permissions/Role.php
+++ b/src/Models/Permissions/Role.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * MIT License
  *
@@ -44,11 +46,13 @@ class Role extends SpatieRole
         ];
     }
 
+    /** @return HasMany<Affiliation, $this> */
     public function affiliations(): HasMany
     {
         return $this->hasMany(Affiliation::class, 'role_id');
     }
 
+    /** @return HasMany<RoleMembership, $this> */
     public function role_memberships(): HasMany
     {
         return $this->hasMany(RoleMembership::class, 'role_id');

--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * MIT License
  *
@@ -75,11 +77,13 @@ class User extends Authenticatable
         ];
     }
 
+    /** @return HasMany<CharacterUser, $this> */
     public function character_users(): HasMany
     {
         return $this->hasMany(CharacterUser::class, 'user_id', 'id');
     }
 
+    /** @return HasManyThrough<CharacterInfo, CharacterUser, $this> */
     public function characters(): HasManyThrough
     {
         return $this->hasManyThrough(
@@ -92,6 +96,7 @@ class User extends Authenticatable
         );
     }
 
+    /** @return HasOne<CharacterInfo, $this> */
     public function main_character(): HasOne
     {
         return $this->hasOne(CharacterInfo::class, 'character_id', 'main_character_id');
@@ -105,6 +110,7 @@ class User extends Authenticatable
         });
     }
 
+    /** @return MorphOne<Application, $this> */
     public function application(): MorphOne
     {
         return $this->morphOne(Application::class, 'applicationable')->whereStatus('open');

--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -78,7 +78,7 @@ class User extends Authenticatable
     }
 
     /** @return HasMany<CharacterUser, $this> */
-    public function character_users(): HasMany
+    public function characterUsers(): HasMany
     {
         return $this->hasMany(CharacterUser::class, 'user_id', 'id');
     }
@@ -97,7 +97,7 @@ class User extends Authenticatable
     }
 
     /** @return HasOne<CharacterInfo, $this> */
-    public function main_character(): HasOne
+    public function mainCharacter(): HasOne
     {
         return $this->hasOne(CharacterInfo::class, 'character_id', 'main_character_id');
     }

--- a/src/Observers/ApplicationObserver.php
+++ b/src/Observers/ApplicationObserver.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * MIT License
  *

--- a/src/Observers/CharacterAffiliationObserver.php
+++ b/src/Observers/CharacterAffiliationObserver.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * MIT License
  *

--- a/src/Observers/CharacterAffiliationObserver.php
+++ b/src/Observers/CharacterAffiliationObserver.php
@@ -52,9 +52,9 @@ class CharacterAffiliationObserver
             return;
         }
 
-        $is_main_character = $character_user->user->main_character_id === $affiliation->character_id;
+        $is_mainCharacter = $character_user->user->main_character_id === $affiliation->character_id;
 
-        if ($is_main_character) {
+        if ($is_mainCharacter) {
             $new_main_character_id = $character_user->user->characters->pluck('character_id')->reject(fn (int $id) => $id === $affiliation->character_id)->first();
 
             // update user

--- a/src/Observers/SsoScopeObserver.php
+++ b/src/Observers/SsoScopeObserver.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * MIT License
  *

--- a/src/Services/AuthenticationService.php
+++ b/src/Services/AuthenticationService.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Seatplus\Auth\Services;
 
 use Illuminate\Contracts\Auth\Guard;

--- a/src/Services/Permissions/CanUserService.php
+++ b/src/Services/Permissions/CanUserService.php
@@ -14,10 +14,8 @@ use Seatplus\Auth\Services\Permissions\DTO\ValidateIdsDTO;
 class CanUserService
 {
     public function __construct(
-        private ?UserPermissionService $user_permission_service = null
-    ) {
-        $this->user_permission_service ??= new UserPermissionService;
-    }
+        private readonly UserPermissionService $user_permission_service = new UserPermissionService,
+    ) {}
 
     /**
      * @throws ValidationException

--- a/src/Services/Permissions/CanUserService.php
+++ b/src/Services/Permissions/CanUserService.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Seatplus\Auth\Services\Permissions;
 
 use Closure;
@@ -152,7 +154,7 @@ class CanUserService
         return (bool) array_intersect($corporation_role, $users_corporation_roles);
     }
 
-    public function getUserPermissionObject(User $user): mixed
+    public function getUserPermissionObject(User $user): array
     {
         return Cache::remember("user_permissions_{$user->id}", now()->addMinutes(5), fn () => $this->user_permission_service->get($user));
     }

--- a/src/Services/Permissions/CanUserService.php
+++ b/src/Services/Permissions/CanUserService.php
@@ -14,7 +14,7 @@ use Seatplus\Auth\Services\Permissions\DTO\ValidateIdsDTO;
 class CanUserService
 {
     public function __construct(
-        private readonly UserPermissionService $user_permission_service = new UserPermissionService,
+        private readonly UserPermissionService $userPermissionService = new UserPermissionService,
     ) {}
 
     /**
@@ -154,6 +154,6 @@ class CanUserService
 
     public function getUserPermissionObject(User $user): array
     {
-        return Cache::remember("user_permissions_{$user->id}", now()->addMinutes(5), fn () => $this->user_permission_service->get($user));
+        return Cache::remember("user_permissions_{$user->id}", now()->addMinutes(5), fn () => $this->userPermissionService->get($user));
     }
 }

--- a/src/Services/Permissions/DTO/ValidateIdsDTO.php
+++ b/src/Services/Permissions/DTO/ValidateIdsDTO.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Seatplus\Auth\Services\Permissions\DTO;
 
 use Illuminate\Http\Request;
@@ -20,16 +22,18 @@ class ValidateIdsDTO
 
     public static function fromRequest(Request $request): ValidateIdsDTO
     {
-
         $all_data = [...$request->all(), ...$request->route()->parameters()];
 
+        $toInt = fn (mixed $v): ?int => $v !== null ? (int) $v : null;
+        $toIntArray = fn (mixed $v): ?array => $v !== null ? array_map('intval', (array) $v) : null;
+
         return new self(
-            character_id: Arr::get($all_data, 'character_id'),
-            corporation_id: Arr::get($all_data, 'corporation_id'),
-            alliance_id: Arr::get($all_data, 'alliance_id'),
-            character_ids: Arr::get($all_data, 'character_ids'),
-            corporation_ids: Arr::get($all_data, 'corporation_ids'),
-            alliance_ids: Arr::get($all_data, 'alliance_ids')
+            character_id: $toInt(Arr::get($all_data, 'character_id')),
+            corporation_id: $toInt(Arr::get($all_data, 'corporation_id')),
+            alliance_id: $toInt(Arr::get($all_data, 'alliance_id')),
+            character_ids: $toIntArray(Arr::get($all_data, 'character_ids')),
+            corporation_ids: $toIntArray(Arr::get($all_data, 'corporation_ids')),
+            alliance_ids: $toIntArray(Arr::get($all_data, 'alliance_ids')),
         );
     }
 

--- a/src/Services/Permissions/DTO/ValidateIdsDTO.php
+++ b/src/Services/Permissions/DTO/ValidateIdsDTO.php
@@ -8,6 +8,7 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Validation\ValidationException;
+use InvalidArgumentException;
 
 class ValidateIdsDTO
 {
@@ -81,7 +82,9 @@ class ValidateIdsDTO
 
         $presentKeys = array_filter($keys, fn (string $key) => ! is_null($ids[$key] ?? null));
 
-        abort_unless(count($presentKeys) === 1, 403, 'Exactly one of the parameters ['.implode(', ', $keys).'] must be present.');
+        if (count($presentKeys) !== 1) {
+            throw new InvalidArgumentException('Exactly one of the parameters ['.implode(', ', $keys).'] must be present.');
+        }
 
         $validator = Validator::make($ids, [
             'character_id' => 'nullable|integer',
@@ -95,7 +98,9 @@ class ValidateIdsDTO
             'alliance_ids.*' => 'integer',
         ]);
 
-        abort_if($validator->fails(), 403, implode(', ', $validator->errors()->all()));
+        if ($validator->fails()) {
+            throw new InvalidArgumentException(implode(', ', $validator->errors()->all()));
+        }
 
         return $validator->validated();
     }

--- a/src/Services/Permissions/RolePermissionObjectService.php
+++ b/src/Services/Permissions/RolePermissionObjectService.php
@@ -12,10 +12,8 @@ use Seatplus\Auth\Services\Roles\RoleAffiliatedIdsService;
 class RolePermissionObjectService
 {
     public function __construct(
-        private ?RoleAffiliatedIdsService $role_affiliated_ids_service = null
-    ) {
-        $this->role_affiliated_ids_service = $role_affiliated_ids_service ?? new RoleAffiliatedIdsService;
-    }
+        private readonly RoleAffiliatedIdsService $role_affiliated_ids_service = new RoleAffiliatedIdsService,
+    ) {}
 
     public function get(Role $role): Collection
     {

--- a/src/Services/Permissions/RolePermissionObjectService.php
+++ b/src/Services/Permissions/RolePermissionObjectService.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Seatplus\Auth\Services\Permissions;
 
 use Illuminate\Support\Collection;

--- a/src/Services/Permissions/RolePermissionObjectService.php
+++ b/src/Services/Permissions/RolePermissionObjectService.php
@@ -12,14 +12,14 @@ use Seatplus\Auth\Services\Roles\RoleAffiliatedIdsService;
 class RolePermissionObjectService
 {
     public function __construct(
-        private readonly RoleAffiliatedIdsService $role_affiliated_ids_service = new RoleAffiliatedIdsService,
+        private readonly RoleAffiliatedIdsService $roleAffiliatedIdsService = new RoleAffiliatedIdsService,
     ) {}
 
     public function get(Role $role): Collection
     {
         $role = $role->loadMissing('permissions');
 
-        $affiliated_ids = $this->role_affiliated_ids_service->get($role);
+        $affiliated_ids = $this->roleAffiliatedIdsService->get($role);
 
         return $role->permissions
             ->mapWithKeys(fn (Permission $permission) => [$permission->name => $affiliated_ids]);

--- a/src/Services/Permissions/UserPermissionService.php
+++ b/src/Services/Permissions/UserPermissionService.php
@@ -10,14 +10,14 @@ use Seatplus\Eveapi\Models\Character\CharacterInfo;
 
 class UserPermissionService
 {
-    private array $corporation_roles = [];
+    private array $corporationRoles = [];
 
     private array $permissions = [];
 
-    private array $character_ids = [];
+    private array $characterIds = [];
 
     public function __construct(
-        private readonly RolePermissionObjectService $role_permission_object_service = new RolePermissionObjectService,
+        private readonly RolePermissionObjectService $rolePermissionObjectService = new RolePermissionObjectService,
     ) {}
 
     public function get(User $user): array
@@ -30,9 +30,9 @@ class UserPermissionService
         $this->buildCharacterIds($user);
 
         return [
-            'corporation_roles' => $this->corporation_roles,
+            'corporation_roles' => $this->corporationRoles,
             'permissions' => $this->permissions,
-            'character_ids' => $this->character_ids,
+            'character_ids' => $this->characterIds,
             'owned_character_ids' => $user->characters->pluck('character_id')->toArray(),
         ];
 
@@ -52,7 +52,7 @@ class UserPermissionService
                 }
 
                 foreach ($roles as $role) {
-                    $this->corporation_roles[$role] = array_merge($this->corporation_roles[$role] ?? [], [$character->corporation_id]);
+                    $this->corporationRoles[$role] = array_merge($this->corporationRoles[$role] ?? [], [$character->corporation_id]);
                 }
             });
     }
@@ -60,7 +60,7 @@ class UserPermissionService
     private function buildPermissions(User $user): void
     {
         $user->roles->each(function (Role $role) {
-            $role_permissions = $this->role_permission_object_service->get($role);
+            $role_permissions = $this->rolePermissionObjectService->get($role);
 
             // merge on permissions. The key might exist, so we extend the array
             $this->permissions = $role_permissions
@@ -72,6 +72,6 @@ class UserPermissionService
 
     private function buildCharacterIds(User $user): void
     {
-        $this->character_ids = $user->characters->pluck('character_id')->toArray();
+        $this->characterIds = $user->characters->pluck('character_id')->toArray();
     }
 }

--- a/src/Services/Permissions/UserPermissionService.php
+++ b/src/Services/Permissions/UserPermissionService.php
@@ -17,10 +17,8 @@ class UserPermissionService
     private array $character_ids = [];
 
     public function __construct(
-        private ?RolePermissionObjectService $role_permission_object_service = null
-    ) {
-        $this->role_permission_object_service = $role_permission_object_service ?? new RolePermissionObjectService;
-    }
+        private readonly RolePermissionObjectService $role_permission_object_service = new RolePermissionObjectService,
+    ) {}
 
     public function get(User $user): array
     {

--- a/src/Services/Permissions/UserPermissionService.php
+++ b/src/Services/Permissions/UserPermissionService.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Seatplus\Auth\Services\Permissions;
 
 use Seatplus\Auth\Models\Permissions\Role;

--- a/src/Services/Roles/AbstractRoleService.php
+++ b/src/Services/Roles/AbstractRoleService.php
@@ -77,7 +77,7 @@ abstract class AbstractRoleService implements RoleServiceInterface
 
     private function getActiveMembers(): \Illuminate\Support\Collection
     {
-        return $this->role->role_memberships()
+        return $this->role->roleMemberships()
             ->where('entity_type', User::class)
             ->where('status', RoleMembershipStatus::ACTIVE)
             ->pluck('entity_id');
@@ -139,12 +139,12 @@ abstract class AbstractRoleService implements RoleServiceInterface
 
     protected function getAssignedCharacterIds(): array
     {
-        $role = $this->role->refresh()->loadMissing(['role_memberships.entity' => function (MorphTo $morph_to) {
+        $role = $this->role->refresh()->loadMissing(['roleMemberships.entity' => function (MorphTo $morph_to) {
             $morph_to->morphWith([CorporationInfo::class => 'characters', AllianceInfo::class => 'characters']);
         }]);
 
         return $role
-            ->role_memberships
+            ->roleMemberships
             ->filter(fn (RoleMembership $role_membership) => $role_membership->entity_type === CorporationInfo::class || $role_membership->entity_type === AllianceInfo::class)
             ->pluck('entity.characters')
             ->flatten()

--- a/src/Services/Roles/AbstractRoleService.php
+++ b/src/Services/Roles/AbstractRoleService.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Seatplus\Auth\Services\Roles;
 
 use Illuminate\Database\Eloquent\Builder;

--- a/src/Services/Roles/AbstractRoleService.php
+++ b/src/Services/Roles/AbstractRoleService.php
@@ -23,7 +23,8 @@ use Seatplus\Eveapi\Models\Corporation\CorporationInfo;
 abstract class AbstractRoleService implements RoleServiceInterface
 {
     public function __construct(
-        protected Role $role
+        protected Role $role,
+        private readonly IsUserCompliantService $isUserCompliantService = new IsUserCompliantService(false),
     ) {}
 
     private function affiliateEntity(int|string $entity_id, string $entity_type, AffiliationType $affiliationType): void
@@ -198,10 +199,7 @@ abstract class AbstractRoleService implements RoleServiceInterface
 
     protected function isUserCompliant(User $user): bool
     {
-        // build a service to check if user is compliant. We do not consider applications here
-        $is_user_compliant_service = new IsUserCompliantService(false);
-
-        return $is_user_compliant_service->check($user);
+        return $this->isUserCompliantService->check($user);
     }
 
     /**

--- a/src/Services/Roles/BaseRoleService.php
+++ b/src/Services/Roles/BaseRoleService.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Seatplus\Auth\Services\Roles;
 
 use Seatplus\Auth\Enums\RoleType;

--- a/src/Services/Roles/ManualRoleService.php
+++ b/src/Services/Roles/ManualRoleService.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Seatplus\Auth\Services\Roles;
 
 use Seatplus\Auth\Enums\RoleMembershipStatus;

--- a/src/Services/Roles/OnRequestRoleService.php
+++ b/src/Services/Roles/OnRequestRoleService.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Seatplus\Auth\Services\Roles;
 
 use Seatplus\Auth\Enums\RoleMembershipStatus;
+use Seatplus\Auth\Exceptions\CriteriaNotMetException;
 use Seatplus\Auth\Models\User;
 use Seatplus\Auth\Services\Roles\DTO\CriteriaData;
 
@@ -26,7 +27,7 @@ class OnRequestRoleService extends AbstractRoleService implements RoleServiceInt
         $meets_criteria = $this->meetsCriteria($user);
 
         if (! $meets_criteria) {
-            throw new \Exception('User does not meet criteria to join role');
+            throw new CriteriaNotMetException;
         }
 
         $this->setRoleMembership(
@@ -37,7 +38,7 @@ class OnRequestRoleService extends AbstractRoleService implements RoleServiceInt
     }
 
     /**
-     * @throws \Exception
+     * @throws CriteriaNotMetException
      */
     public function approveApplicationForRole(User $user): void
     {
@@ -46,7 +47,7 @@ class OnRequestRoleService extends AbstractRoleService implements RoleServiceInt
 
         if (! $meets_criteria) {
             $this->removeRoleMembership($user);
-            throw new \Exception('User does not meet criteria to join role');
+            throw new CriteriaNotMetException;
         }
 
         $this->setRoleMembership(

--- a/src/Services/Roles/RoleAffiliatedIdsService.php
+++ b/src/Services/Roles/RoleAffiliatedIdsService.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Seatplus\Auth\Services\Roles;
 
 use Illuminate\Database\Eloquent\Relations\MorphTo;
@@ -58,7 +60,7 @@ class RoleAffiliatedIdsService
         return $allowed->all();
     }
 
-    public function loadMissingRelationships(Role $role): Role
+    private function loadMissingRelationships(Role $role): Role
     {
         return $role->loadMissing([
             'affiliations.affiliatable' => fn (MorphTo $morph_to) => $morph_to

--- a/src/Services/SsoScopes/BuildScopesArrayService.php
+++ b/src/Services/SsoScopes/BuildScopesArrayService.php
@@ -27,10 +27,8 @@ class BuildScopesArrayService
 
     public function __construct(
         private readonly bool $with_application_scopes = true,
-        private ?GlobalSsoScopesService $globalSsoScopesService = null
-    ) {
-        $this->globalSsoScopesService = $globalSsoScopesService ?? new GlobalSsoScopesService;
-    }
+        private readonly GlobalSsoScopesService $globalSsoScopesService = new GlobalSsoScopesService,
+    ) {}
 
     private function getUserRequiredScopes(User $user): array
     {

--- a/src/Services/SsoScopes/BuildScopesArrayService.php
+++ b/src/Services/SsoScopes/BuildScopesArrayService.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Seatplus\Auth\Services\SsoScopes;
 
 use Illuminate\Database\Eloquent\Builder;
@@ -120,7 +122,6 @@ class BuildScopesArrayService
 
     public function get(User|CharacterInfo $entity): array
     {
-
         $user = User::query()
             ->when($entity instanceof CharacterInfo, fn (Builder $query) => $query
                 ->whereHas('characters', fn (Builder $query) => $query
@@ -129,6 +130,10 @@ class BuildScopesArrayService
             )
             ->with(self::USER_RELATIONS)
             ->first();
+
+        if ($user === null) {
+            return [];
+        }
 
         return $this->build($user);
     }

--- a/src/Services/SsoScopes/BuildScopesArrayService.php
+++ b/src/Services/SsoScopes/BuildScopesArrayService.php
@@ -26,7 +26,7 @@ class BuildScopesArrayService
     ];
 
     public function __construct(
-        private readonly bool $with_application_scopes = true,
+        private readonly bool $withApplicationScopes = true,
         private readonly GlobalSsoScopesService $globalSsoScopesService = new GlobalSsoScopesService,
     ) {}
 
@@ -115,7 +115,7 @@ class BuildScopesArrayService
 
     private function isWithApplicationScopes(): bool
     {
-        return $this->with_application_scopes;
+        return $this->withApplicationScopes;
     }
 
     public function get(User|CharacterInfo $entity): array

--- a/src/Services/SsoScopes/GlobalSsoScopesService.php
+++ b/src/Services/SsoScopes/GlobalSsoScopesService.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Seatplus\Auth\Services\SsoScopes;
 
 use Seatplus\Eveapi\Models\SsoScopes;

--- a/src/Services/SsoScopes/IsUserCompliantService.php
+++ b/src/Services/SsoScopes/IsUserCompliantService.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Seatplus\Auth\Services\SsoScopes;
 
 use Seatplus\Auth\Models\User;

--- a/src/Services/SsoScopes/IsUserCompliantService.php
+++ b/src/Services/SsoScopes/IsUserCompliantService.php
@@ -8,12 +8,12 @@ use Seatplus\Auth\Models\User;
 
 class IsUserCompliantService
 {
-    private readonly BuildScopesArrayService $build_scopes_array_service;
+    private readonly BuildScopesArrayService $buildScopesArrayService;
 
     public function __construct(
-        private readonly bool $consider_applications = true
+        private readonly bool $considerApplications = true
     ) {
-        $this->build_scopes_array_service = new BuildScopesArrayService($this->consider_applications);
+        $this->buildScopesArrayService = new BuildScopesArrayService($this->considerApplications);
     }
 
     public function check(User $user): bool
@@ -25,7 +25,7 @@ class IsUserCompliantService
 
     public function getMissingScopes(User $user): array
     {
-        $scopes = $this->build_scopes_array_service
+        $scopes = $this->buildScopesArrayService
             ->get($user);
 
         return collect($scopes)

--- a/tests/Feature/Routes/MainCharacterTest.php
+++ b/tests/Feature/Routes/MainCharacterTest.php
@@ -5,7 +5,7 @@ use Seatplus\Auth\Models\CharacterUser;
 test('one can change main character', function () {
     $secondary = CharacterUser::factory()->make();
 
-    test()->test_user->character_users()->save($secondary);
+    test()->test_user->characterUsers()->save($secondary);
 
     test()->test_user = test()->test_user->refresh();
 

--- a/tests/Feature/Routes/SsoControllerTest.php
+++ b/tests/Feature/Routes/SsoControllerTest.php
@@ -94,7 +94,7 @@ test('one can add another character', function () {
     ]);
 
     // expect test_user only to have one character
-    expect(test()->test_user->character_users)->toHaveCount(1);
+    expect(test()->test_user->characterUsers)->toHaveCount(1);
 
     // assert no UserRolesSync job has been dispatched
     Queue::assertNothingPushed();
@@ -109,5 +109,5 @@ test('one can add another character', function () {
 
     expect(session('success'))->toBe('Character added/updated successfully');
 
-    expect(test()->test_user->refresh()->character_users)->toHaveCount(2);
+    expect(test()->test_user->refresh()->characterUsers)->toHaveCount(2);
 });

--- a/tests/Unit/FindOrCreateUserActionTest.php
+++ b/tests/Unit/FindOrCreateUserActionTest.php
@@ -49,14 +49,14 @@ test('create new user', function () {
 
 test('find existing user with two character', function () {
     // add 3 characters to test_user
-    test()->test_user->character_users()->createMany(
+    test()->test_user->characterUsers()->createMany(
         CharacterUser::factory()->count(3)->make()->toArray()
     );
 
-    expect(test()->test_user->character_users->count())->toEqual(4);
+    expect(test()->test_user->characterUsers->count())->toEqual(4);
 
     // select last character to login
-    $secondary_character = test()->test_user->character_users->last();
+    $secondary_character = test()->test_user->characterUsers->last();
 
     $eve_user = createEveUser(
         $secondary_character->character_id,
@@ -75,10 +75,10 @@ test('find existing user with two character', function () {
 });
 
 test('deal with changed owner hash', function () {
-    expect(1)->toEqual(test()->test_user->character_users->count());
+    expect(1)->toEqual(test()->test_user->characterUsers->count());
 
     $eve_user = createEveUser(
-        test()->test_user->character_users->first()->character_id,
+        test()->test_user->characterUsers->first()->character_id,
         'anotherHashValue'
     );
 
@@ -106,9 +106,9 @@ test('deal with two characters with one changed owner hash', function () {
     $secondary_user = CharacterUser::factory()->make();
 
     // 2. assign secondary user to test_user
-    test()->test_user->character_users()->save($secondary_user);
+    test()->test_user->characterUsers()->save($secondary_user);
 
-    expect(test()->test_user->character_users->count())->toEqual(2);
+    expect(test()->test_user->characterUsers->count())->toEqual(2);
 
     // 3. find user
 
@@ -120,7 +120,7 @@ test('deal with two characters with one changed owner hash', function () {
     $action = new FindOrCreateUserAction;
     $user = $action($eve_user);
 
-    expect($user->character_users->count())->toEqual(1);
+    expect($user->characterUsers->count())->toEqual(1);
 
     expect(CharacterUser::all()->count())->toEqual(2);
 
@@ -172,5 +172,5 @@ it('returns authed user', function () {
         'character_id' => $secondary_user->character_id,
     ]);
 
-    expect(test()->test_user->character_users->count())->toEqual(2);
+    expect(test()->test_user->characterUsers->count())->toEqual(2);
 });

--- a/tests/Unit/Middleware/CheckRequiredScopesTest.php
+++ b/tests/Unit/Middleware/CheckRequiredScopesTest.php
@@ -369,6 +369,8 @@ function mockRequest(): void
 
     test()->next = function ($request) {
         $request->forward();
+
+        return response('OK');
     };
 }
 

--- a/tests/Unit/Middleware/CheckRequiredScopesTest.php
+++ b/tests/Unit/Middleware/CheckRequiredScopesTest.php
@@ -98,7 +98,7 @@ describe('redirect request', function () {
         // Create secondary character
         $secondary_character = Event::fakeFor(function () {
             $character_user = CharacterUser::factory()->make();
-            test()->test_user->character_users()->save($character_user);
+            test()->test_user->characterUsers()->save($character_user);
 
             return CharacterInfo::find($character_user->character_id);
         });
@@ -264,7 +264,7 @@ describe('passes middleware', function () {
         // Create secondary character
         $secondary_character = Event::fakeFor(function () {
             $character_user = CharacterUser::factory()->make();
-            test()->test_user->character_users()->save($character_user);
+            test()->test_user->characterUsers()->save($character_user);
 
             return CharacterInfo::find($character_user->character_id);
         });

--- a/tests/Unit/Models/CharacterUserTest.php
+++ b/tests/Unit/Models/CharacterUserTest.php
@@ -3,7 +3,7 @@
 it('has character', function () {
     $test_user = $this->test_user;
 
-    $character_user = $test_user->character_users->first();
+    $character_user = $test_user->characterUsers->first();
 
     expect($character_user->character->character_id)->toBe($this->test_character->character_id);
 });

--- a/tests/Unit/Models/RoleModelTest.php
+++ b/tests/Unit/Models/RoleModelTest.php
@@ -97,5 +97,5 @@ it('has role memberships', function () {
         'entity_type' => CorporationInfo::class,
     ]);
 
-    expect(test()->role->role_memberships->first()->entity)->toBeInstanceOf(CorporationInfo::class);
+    expect(test()->role->roleMemberships->first()->entity)->toBeInstanceOf(CorporationInfo::class);
 });

--- a/tests/Unit/Models/UserTest.php
+++ b/tests/Unit/Models/UserTest.php
@@ -37,18 +37,18 @@ beforeEach(function () {
 it('has main character relationship', function () {
     $test_user = User::factory()->create();
 
-    expect($test_user->main_character)->toBeInstanceOf(CharacterInfo::class);
+    expect($test_user->mainCharacter)->toBeInstanceOf(CharacterInfo::class);
 });
 
 it('has characters relationship', function () {
     $test_user = User::factory()->create();
 
     test()->assertDatabaseHas('character_users', [
-        'character_id' => $test_user->character_users->first()->character_id,
+        'character_id' => $test_user->characterUsers->first()->character_id,
     ]);
 
     test()->assertDatabaseHas('character_infos', [
-        'character_id' => $test_user->character_users->first()->character_id,
+        'character_id' => $test_user->characterUsers->first()->character_id,
     ]);
 
     expect($test_user->characters->first())->toBeInstanceOf(CharacterInfo::class);

--- a/tests/Unit/Services/Roles/OnRequestRoleServiceTest.php
+++ b/tests/Unit/Services/Roles/OnRequestRoleServiceTest.php
@@ -2,6 +2,7 @@
 
 use Seatplus\Auth\Enums\RoleMembershipStatus;
 use Seatplus\Auth\Enums\RoleType;
+use Seatplus\Auth\Exceptions\CriteriaNotMetException;
 use Seatplus\Auth\Models\AccessControl\RoleMembership;
 use Seatplus\Auth\Models\Permissions\Role;
 use Seatplus\Auth\Models\User;
@@ -79,7 +80,7 @@ it('cannot submit application if no criteria is set', function () {
 
     // assert
 
-})->throws(Exception::class, 'User does not meet criteria to join role');
+})->throws(CriteriaNotMetException::class, 'User does not meet criteria to join role');
 
 it('submits application for role', function () {
     // arrange
@@ -124,7 +125,7 @@ it('throws exception when approving application for role with no criteria', func
     $this->service->approveApplicationForRole($user);
 
     // assert
-})->throws(Exception::class, 'User does not meet criteria to join role');
+})->throws(CriteriaNotMetException::class, 'User does not meet criteria to join role');
 
 it('denies application for role', function () {
     // arrange


### PR DESCRIPTION
Rebases the Groups 1-4 code quality commits cleanly onto `4.x` (the original PR #408 was merged into `chore/ci-overhaul` *after* that branch was already merged into `4.x`).

## Changes
- **Group 1** — strict types, return types, Eloquent generics, null guards
- **Group 2** — replace nullable DI anti-patterns with PHP 8.1 new-in-initializers
- **Group 3** — domain exceptions, remove `abort_unless`/`abort_if` from services
- **Group 4** — rename snake_case relations/service properties to camelCase (`character_users` → `characterUsers`, `main_character` → `mainCharacter`, `role_memberships` → `roleMemberships`)