### PR TITLE
fix: cast EVE SSO character_id to int

### DIFF
--- a/src/Http/Controllers/Auth/CallbackController.php
+++ b/src/Http/Controllers/Auth/CallbackController.php
@@ -29,7 +29,8 @@ class CallbackController
         $socialite_user = $social->driver('eveonline')->user();
 
         $eve_data = new EveUser(
-            character_id: data_get($socialite_user, 'attributes.character_id'),
+            // EVE SSO returns character_id as a string; EveUser (strict_types) expects int.
+            character_id: (int) data_get($socialite_user, 'attributes.character_id'),
             character_owner_hash: data_get($socialite_user, 'attributes.character_owner_hash'),
             token: data_get($socialite_user, 'token'),
             refreshToken: data_get($socialite_user, 'refreshToken'),

--- a/tests/Unit/Controllers/CallbackControllerTest.php
+++ b/tests/Unit/Controllers/CallbackControllerTest.php
@@ -17,7 +17,7 @@ it('redirects back with error message on login failure', function () {
     });
 
     $socialite_user->attributes = (object) [
-        'character_id' => 1,
+        'character_id' => '1', // EVE SSO provider returns this as a string
         'character_owner_hash' => faker()->sha256,
     ];
     $socialite_user->token = 'token';
@@ -58,7 +58,7 @@ it('redirects back if different character id is provided', function () {
     });
 
     $socialite_user->attributes = (object) [
-        'character_id' => 1,
+        'character_id' => '1', // EVE SSO provider returns this as a string
         'character_owner_hash' => faker()->sha256,
     ];
     $socialite_user->token = 'token';


### PR DESCRIPTION
The eveonline Socialite provider returns `attributes.character_id` as a **string**, but `EveUser` (`declare(strict_types=1)`) requires `int` — so the SSO callback threw a `TypeError` in `CallbackController` and login failed. Cast at the boundary.

The unit test mocked `character_id` as an int (so it never caught this); it now mocks the realistic string to guard the regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)